### PR TITLE
fix: Add dolt runtime files to .beads/.gitignore

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -10,6 +10,8 @@ bd.sock
 bd.sock.startlock
 sync-state.json
 last-touched
+dolt-server.*
+dolt-monitor.*
 
 # Local version tracking (prevents upgrade notification spam after git ops)
 .local_version


### PR DESCRIPTION
## Summary
- Added `dolt-server.*` and `dolt-monitor.*` glob patterns to `.beads/.gitignore`
- These are machine-specific runtime artifacts from dolt sql-server (pid, port, log, lock, activity) that should not be tracked by git

## Changes
- 4c5d24a fix: Add dolt runtime files to .beads/.gitignore

## Task
lets-3i0.2: Add dolt runtime files to .beads/.gitignore

---
Generated with LETS plugin