### PR TITLE
fix: Quick wins batch - 8 plugin fixes

### DIFF
--- a/agents/docs.md
+++ b/agents/docs.md
@@ -20,6 +20,17 @@ You are a senior technical writer with deep experience in developer documentatio
 - Documentation-code synchronization
 - Diagram and visual documentation
 
+## LETS Plugin Documentation
+
+When reviewing a Claude Code plugin (commands/*.md, agents/*.md, hooks/), also check:
+
+- **CLAUDE.md** - Structure section matches actual file layout, Architecture Decisions are current, File Storage paths are accurate
+- **hooks/rules-context.md** - Skill Quick Reference table includes all commands from commands/*.md
+- **commands/install.md** - Essential Skills and Planning Skills tables match actual available commands
+- **Command descriptions** (frontmatter `description:` field) - match what the command actually does
+
+Cross-reference: if a new command was added/renamed/removed, ALL three files above must be updated.
+
 ## How You Think
 
 You think about the developer who reads this next. You ask:

--- a/commands/ask.md
+++ b/commands/ask.md
@@ -76,7 +76,7 @@ If passed as argument - use it. Otherwise ask the user.
 Before launching the agent, gather relevant context:
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 cat "$ROOT/CLAUDE.md" 2>/dev/null | head -100
 ```
 

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -73,7 +73,7 @@ Wait for user answers before proceeding.
 Gather project context:
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 cat "$ROOT/CLAUDE.md" 2>/dev/null | head -200
 ```
 
@@ -610,7 +610,7 @@ Derive plan filename from the current branch:
 ```bash
 BRANCH=$(git branch --show-current)
 SLUG="${BRANCH#feature/}"   # e.g., 0nf.10-improve-brainstorm
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 mkdir -p "$ROOT/.lets/plans"
 ```
 

--- a/commands/check.md
+++ b/commands/check.md
@@ -42,7 +42,7 @@ If no changes, inform user and exit.
 ## Step 2: Gather Context
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 git diff --stat
 cat "$ROOT/CLAUDE.md" 2>/dev/null | head -100
 ```

--- a/commands/end.md
+++ b/commands/end.md
@@ -43,7 +43,7 @@ If `--fast` argument provided, skip to Fast Close below and do NOT run Steps 1-7
    ```bash
    git rev-parse HEAD > "$ROOT/.lets/sessions/.session-start-ref-${BRANCH_SLUG}"
    ```
-5. Worktree detection - same as Step 7: if in worktree and task in progress, show resume path
+5. Worktree detection: check `GIT_DIR` as in Step 7. If in worktree and task in progress, add resume path. If task completed, add cleanup reminder.
 6. Output fast close block and stop - no AskUserQuestion, no bd sync
 
 ### Fast Close Output
@@ -53,7 +53,9 @@ If `--fast` argument provided, skip to Fast Close below and do NOT run Steps 1-7
 
 Branch: {branch}
 Task: {task-id or "none"}
-{worktree block if applicable - same format as normal output}
+Worktree: {name} (if in worktree)
+Resume:   cd $ROOT && claude -> /lets:start (if task in progress)
+Cleanup:  /lets:worktree remove {name} (if task completed)
 
 ┌─ LETS ─────────────────────────┐
 │  Resume?  /lets:start          │
@@ -217,7 +219,7 @@ Check if in a worktree:
 
 ```bash
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
-WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+# ROOT = project-root from LETS Config
 ```
 
 If `$GIT_DIR` contains `worktrees/`:
@@ -247,7 +249,7 @@ If in worktree and task is still in progress, add:
 
 ```
 Worktree: {name}
-Resume:   cd $WORKTREE_ROOT && claude -> /lets:start
+Resume:   cd $ROOT && claude -> /lets:start
 ```
 
 Then use **AskUserQuestion** for next steps:

--- a/commands/end.md
+++ b/commands/end.md
@@ -1,5 +1,6 @@
 ---
 description: End work session - save progress, sync beads, create summary
+argument-hint: "[--fast]"
 ---
 
 # Session End
@@ -7,6 +8,59 @@ description: End work session - save progress, sync beads, create summary
 End a work session properly. Save context for next session.
 
 **This is NOT task completion.** Use `/lets:done` to finish a task. `/lets:end` ends a SESSION.
+
+## Fast Mode
+
+If `--fast` argument provided, skip to Fast Close below and do NOT run Steps 1-7.
+
+### Fast Close
+
+1. `git status --short` - check uncommitted changes
+2. If uncommitted changes exist -> warn: "Uncommitted changes on disk. Run /lets:commit in next session."
+   Do NOT run /lets:commit or AskUserQuestion (saves tokens)
+3. Save minimal summary:
+   ```bash
+   # ROOT = project-root from LETS Config
+   BRANCH=$(git branch --show-current)
+   BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
+   GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+   mkdir -p "$ROOT/.lets/sessions"
+   # If in worktree, use branch-slug filename; otherwise use default
+   if echo "$GIT_DIR" | grep -q "worktrees/"; then
+     SUMMARY_FILE="$ROOT/.lets/sessions/last-summary-${BRANCH_SLUG}.md"
+   else
+     SUMMARY_FILE="$ROOT/.lets/sessions/last-summary.md"
+   fi
+   ```
+   Write to `$SUMMARY_FILE`:
+   ```
+   ## Fast close {YYYY-MM-DD HH:MM}
+   Branch: {branch}
+   Task: {task-id or "none"}
+   Status: fast close
+   ```
+4. Save session-start-ref:
+   ```bash
+   git rev-parse HEAD > "$ROOT/.lets/sessions/.session-start-ref-${BRANCH_SLUG}"
+   ```
+5. Worktree detection - same as Step 7: if in worktree and task in progress, show resume path
+6. Output fast close block and stop - no AskUserQuestion, no bd sync
+
+### Fast Close Output
+
+```
+## Session End (fast)
+
+Branch: {branch}
+Task: {task-id or "none"}
+{worktree block if applicable - same format as normal output}
+
+┌─ LETS ─────────────────────────┐
+│  Resume?  /lets:start          │
+└────────────────────────────────┘
+```
+
+---
 
 ## Step 1: Check State
 
@@ -44,7 +98,7 @@ For each in-progress task, record this session's work:
 
 ```bash
 # Get this session's commits (per-branch ref supports parallel worktree sessions)
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 BRANCH=$(git branch --show-current)
 BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
 START_REF=$(cat "$ROOT/.lets/sessions/.session-start-ref-${BRANCH_SLUG}" 2>/dev/null)
@@ -105,13 +159,24 @@ AskUserQuestion(
 
 Create TWO files:
 1. **Dated archive:** `.lets/sessions/YYYY-MM-DD-HHMM.md`
-2. **Latest:** `.lets/sessions/last-summary.md` (overwritten each session)
+2. **Latest:** `last-summary-{branch-slug}.md` in worktree, `last-summary.md` in main repo
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
+BRANCH=$(git branch --show-current)
+BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 mkdir -p "$ROOT/.lets/sessions"
 DATED_FILE="$ROOT/.lets/sessions/$(date +%Y-%m-%d-%H%M).md"
+# If in worktree, use branch-slug filename; otherwise use default
+if echo "$GIT_DIR" | grep -q "worktrees/"; then
+  LATEST_FILE="$ROOT/.lets/sessions/last-summary-${BRANCH_SLUG}.md"
+else
+  LATEST_FILE="$ROOT/.lets/sessions/last-summary.md"
+fi
 ```
+
+Write summary to both `$DATED_FILE` and `$LATEST_FILE`.
 
 **Summary template:**
 

--- a/commands/end.md
+++ b/commands/end.md
@@ -152,12 +152,13 @@ Check if in a worktree:
 
 ```bash
 GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+WORKTREE_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
 ```
 
 If `$GIT_DIR` contains `worktrees/`:
 - Extract worktree name from path (last segment of worktree directory)
 - If task was completed this session (PR created or merged via `/lets:done`): remind about cleanup
-- If task is still in progress: no reminder needed - user will return to this worktree
+- If task is still in progress: show the worktree path so user can resume next session with a copy-paste command
 
 ## Output
 
@@ -175,6 +176,13 @@ If in worktree and task is done, add:
 
 ```
 Worktree: {name} - after PR merges, clean up with `/lets:worktree remove {name}` from main repo
+```
+
+If in worktree and task is still in progress, add:
+
+```
+Worktree: {name}
+Resume:   cd $WORKTREE_ROOT && claude -> /lets:start
 ```
 
 Then use **AskUserQuestion** for next steps:

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -33,7 +33,7 @@ Verify not on main/master:
 Plan filename matches the branch slug (branch name without `feature/` prefix).
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 
 # Primary: derive from branch name
 # feature/0nf.10-improve-brainstorm -> 0nf.10-improve-brainstorm.md
@@ -60,7 +60,7 @@ Parse plan structure:
 Check for existing execution state (multi-session resume):
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 cat "$ROOT/.lets/execution/{branch-slug}.json" 2>/dev/null
 ```
 
@@ -270,7 +270,7 @@ After each task completes (committed or not):
 
 Update `.lets/execution/{branch-slug}.json`:
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 mkdir -p "$ROOT/.lets/execution"
 # Write updated state with newly completed task
 ```
@@ -353,7 +353,7 @@ Run the plan's `## Success Criteria` checks.
 Delete `.lets/execution/{branch-slug}.json` - execution is complete, state no longer needed. Beads comment preserves the history.
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 rm "$ROOT/.lets/execution/{branch-slug}.json" 2>/dev/null
 ```
 

--- a/commands/install.md
+++ b/commands/install.md
@@ -41,7 +41,7 @@ bd init
 ### Create .lets/ directory and gitignore
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 mkdir -p "$ROOT/.lets/sessions" "$ROOT/.lets/reviews" "$ROOT/.lets/plans"
 
 # Add .lets/ to .gitignore if not already there
@@ -63,7 +63,7 @@ If `gh auth status` succeeded in Step 1, ask:
 If user agrees:
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 CONFIG="$ROOT/.lets/config.yaml"
 if [ -f "$CONFIG" ]; then
   # Replace existing github line or append if missing

--- a/commands/migrate.md
+++ b/commands/migrate.md
@@ -9,7 +9,7 @@ One-time migration. Run once per project, then delete this command.
 ## Step 1: Check State
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 ls -la "$ROOT/.claude/sessions/" 2>/dev/null
 ls -la "$ROOT/.lets/" 2>/dev/null
 ```
@@ -20,7 +20,7 @@ ls -la "$ROOT/.lets/" 2>/dev/null
 ## Step 2: Migrate
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 mkdir -p "$ROOT/.lets/sessions" "$ROOT/.lets/reviews" "$ROOT/.lets/plans"
 
 # Add .lets/ to .gitignore if not already there
@@ -43,7 +43,7 @@ rm -rf "$ROOT/.claude/sessions"
 ## Step 3: Verify
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 echo "Sessions:" && ls "$ROOT/.lets/sessions/" 2>/dev/null
 echo "Reviews:" && ls "$ROOT/.lets/reviews/" 2>/dev/null
 echo "Old folder:" && ls "$ROOT/.claude/sessions/" 2>/dev/null || echo "removed"

--- a/commands/note.md
+++ b/commands/note.md
@@ -114,12 +114,12 @@ bd comments add <task-id> "## {Note type} {YYYY-MM-DD}
 **Options:** {possible solutions}
 ```
 
-## Step 5: Update Description (if needed)
+## Step 5: Record Scope Change (if needed)
 
-If the task scope or understanding changed significantly:
+If the task scope or understanding changed significantly, record it as a comment (never overwrite the description):
 
 ```bash
-bd update <task-id> --description="<updated description>"
+bd comments add <task-id> "[scope-change] <what changed and why>"
 ```
 
 ## Step 6: Verify

--- a/commands/opinion.md
+++ b/commands/opinion.md
@@ -42,7 +42,7 @@ Based on the decision topic, select 3-5 agents:
 ## Step 3: Gather Context
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 cat "$ROOT/CLAUDE.md" 2>/dev/null | head -100
 ```
 

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -47,7 +47,7 @@ Interpret user intent:
 ### Check for existing state
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 PR_DIR="$ROOT/.lets/execution/pr-{number}"
 STATE_FILE="$PR_DIR/review.json"
 ```
@@ -146,7 +146,23 @@ BRANCH=$(git branch --show-current)
 
 Store detected task-id for use in `bd comments add` calls throughout the lifecycle.
 
-### 2.3 Save current branch and checkout PR
+### 2.3 Worktree check and branch handling
+
+Detect whether we are running inside a git worktree:
+
+```bash
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+```
+
+**If `$GIT_DIR` contains `worktrees/`** (we are in a worktree):
+- Set `IN_WORKTREE=true`
+- Do NOT run `gh pr checkout` - it would replace the worktree branch
+- Skip all stash handling (no branch switch = no conflicts)
+- Use `gh pr diff <PR>` for diff data
+- Use `gh pr view <PR> --json` for all metadata (fetched in 2.1)
+- Proceed directly to state file creation
+
+**If not in worktree:** Continue with existing checkout flow below.
 
 IMPORTANT: Before checking out the PR branch, save current state.
 
@@ -190,7 +206,7 @@ If checkout fails:
 ### 2.3 Create state file
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 mkdir -p "$PR_DIR"
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 ```
@@ -209,6 +225,7 @@ Write initial state to `.lets/execution/pr-{number}/review.json` with Phase 1 fi
   "head_sha": "abc1234def5678",
   "previous_branch": "feature/my-current-work",
   "stashed": false,
+  "in_worktree": false,
   "task_id": "lets-plugin-claude-0nf.26",
   "review_started": "2026-02-26",
   "findings": [],
@@ -389,7 +406,7 @@ All inline comments go in a single review submission via gh api.
 Step 1: Build the complete review JSON payload.
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
 HEAD_SHA=$(gh pr view <PR> --json headRefOid -q .headRefOid)
 ```
@@ -457,7 +474,7 @@ gh pr comment <PR> --body-file "$PR_DIR/fallback.md"
 If there are findings with disposition "summary" or "edited" that weren't included in inline:
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 ```
 
 Write to `$PR_DIR/summary.md`:
@@ -638,7 +655,7 @@ AskUserQuestion(
 ### 5.3 Submit verdict
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 ```
 
 Write verdict body to `$PR_DIR/verdict.md`:
@@ -703,13 +720,15 @@ gh pr merge <PR> --merge --delete-branch
 
 After merge or after approve (if not merging):
 
-1. Switch back to previous_branch:
+1. If NOT `in_worktree` in state:
 
 ```bash
 git checkout {previous_branch from state}
 ```
 
-2. If `stashed: true` in state, warn: "You have a stash from before the PR review. Run `git stash pop` to restore your changes."
+   If `stashed: true` in state, warn: "You have a stash from before the PR review. Run `git stash pop` to restore your changes."
+
+   If `in_worktree` in state: Skip - already on the correct worktree branch.
 
 3. Delete PR folder: `rm -rf "$PR_DIR"`
 
@@ -753,7 +772,12 @@ AskUserQuestion(
 )
 ```
 
-If Checkout: `gh pr checkout <PR>` (same stash handling as Step 2.3).
+If Checkout:
+```bash
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+```
+If in worktree (`$GIT_DIR` contains `worktrees/`): warn "Already in a worktree - cannot checkout PR branch here. Proceeding on current branch." Stay on current branch, skip stash handling.
+Else: `gh pr checkout <PR>` (same stash handling as Step 2.3).
 
 **Detect active task** (before branch switch, same logic as Step 2.2):
 ```bash

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -203,7 +203,7 @@ If checkout fails:
 - Show error and exit: "Failed to checkout PR branch. Check for conflicts."
 - Do NOT create state file on checkout failure.
 
-### 2.3 Create state file
+### 2.4 Create state file
 
 ```bash
 # ROOT = project-root from LETS Config
@@ -225,7 +225,7 @@ Write initial state to `.lets/execution/pr-{number}/review.json` with Phase 1 fi
   "head_sha": "abc1234def5678",
   "previous_branch": "feature/my-current-work",
   "stashed": false,
-  "in_worktree": false,
+  "in_worktree": false,  // set to true if worktree detected in 2.3
   "task_id": "lets-plugin-claude-0nf.26",
   "review_started": "2026-02-26",
   "findings": [],
@@ -248,7 +248,7 @@ Write initial state to `.lets/execution/pr-{number}/review.json` with Phase 1 fi
 - `stashed`: true if user chose "Stash" before checkout - cleanup must warn or pop
 - `task_id`: detected before branch switch, used for `bd comments add` calls
 
-### 2.4 Run review analysis
+### 2.5 Run review analysis
 
 Invoke `/lets:review <PR> --json`.
 
@@ -259,7 +259,7 @@ Copy findings array into state file.
 Copy verdict into state file.
 Save review_json path in state file.
 
-### 2.5 Show findings summary
+### 2.6 Show findings summary
 
 ```
 ## PR #{number}: {title}
@@ -529,9 +529,19 @@ If REVIEW_SHA == CURRENT_SHA:
 
 ### 4.2 Checkout updated PR and get fix delta
 
+If `in_worktree` in state:
+- Skip `gh pr checkout` - use remote ref instead
+- `git fetch origin && git diff ${REVIEW_SHA}..origin/{PR_branch}` for fix delta
+
+If not in worktree:
+
 ```bash
 gh pr checkout <PR>
+```
 
+Then get the fix delta:
+
+```bash
 git log --oneline ${REVIEW_SHA}..HEAD
 git diff ${REVIEW_SHA}..HEAD --stat
 git diff ${REVIEW_SHA}..HEAD
@@ -728,7 +738,7 @@ git checkout {previous_branch from state}
 
    If `stashed: true` in state, warn: "You have a stash from before the PR review. Run `git stash pop` to restore your changes."
 
-   If `in_worktree` in state: Skip - already on the correct worktree branch.
+2. If `in_worktree` in state: Skip branch restore - already on the correct worktree branch.
 
 3. Delete PR folder: `rm -rf "$PR_DIR"`
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -236,7 +236,7 @@ These instructions are **required** for agents that need project-specific contex
 |-------|-----|-------------|
 | `lets:compliance` | Needs rules to check against | "Only flag violations EXPLICITLY mentioned in CLAUDE.md. Quote the rule being violated." |
 | `lets:git-historian` | Needs to access project history | "Use git blame and git log to check historical context of modified files." |
-| `lets:docs` | Needs to know what docs exist | "Check CLAUDE.md sync, docs/ sync, beads tracking, README/config docs." |
+| `lets:docs` | Needs to know what docs exist | "Check LETS plugin doc sync: (1) CLAUDE.md structure and architecture sections match actual files, (2) hooks/rules-context.md Skill Quick Reference table lists all commands, (3) commands/install.md skill tables are complete, (4) command frontmatter descriptions match behavior. When commands/*.md, agents/*.md, or hooks/ files changed - these docs MUST be verified." |
 | `lets:pragmatist` | Specific review lens | "Assess if the solution is proportional to the problem. Flag overengineering." |
 
 ## Step 6: Filter & Aggregate Results

--- a/commands/review.md
+++ b/commands/review.md
@@ -278,7 +278,7 @@ Systemic findings go into a separate section in the final report (see Step 9).
 **CRITICAL: Save first, then show results.**
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 mkdir -p "$ROOT/.lets/reviews"
 ```
 
@@ -293,7 +293,7 @@ Content: Full review report with all issues, verdict, and summary.
 If `--json` flag was provided, save structured JSON and skip Steps 9-10.
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 mkdir -p "$ROOT/.lets/reviews"
 ```
 
@@ -424,7 +424,7 @@ bd comments add <task-id> "Code review ({PR #X | local}): {verdict}. {N} issues 
 ### P1: Load Plan
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 
 # If path provided: use it
 # If no path: derive from branch name

--- a/commands/start.md
+++ b/commands/start.md
@@ -9,8 +9,12 @@ Restore context and prepare for work. **User MUST select a task before working.*
 ## Step 1: Previous Session Context
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
-cat "$ROOT/.lets/sessions/last-summary.md" 2>/dev/null || echo "No previous session"
+# ROOT = project-root from LETS Config
+BRANCH=$(git branch --show-current)
+BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
+cat "$ROOT/.lets/sessions/last-summary-${BRANCH_SLUG}.md" 2>/dev/null \
+  || cat "$ROOT/.lets/sessions/last-summary.md" 2>/dev/null \
+  || echo "No previous session"
 ```
 
 Read and summarize what was done in the last session.
@@ -151,7 +155,7 @@ This recovers context even after conversation compaction.
 After branch is ready, save the starting point for this session. Uses per-branch naming to support parallel sessions in worktrees:
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 BRANCH=$(git branch --show-current)
 BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
 mkdir -p "$ROOT/.lets/sessions"

--- a/commands/status.md
+++ b/commands/status.md
@@ -39,7 +39,7 @@ Compact view. Used by `/lets:start`.
 bd stats
 bd label list-all
 # For each epic:* label:
-bd list --label <label> --json
+bd list --label <label> --json --all
 bd ready --limit 5
 bd list --status=in_progress
 ```
@@ -117,7 +117,7 @@ Output format:
 ```bash
 bd label list-all
 # For each epic:* label:
-bd list --label <label> --json
+bd list --label <label> --json --all
 ```
 
 Output format:
@@ -174,7 +174,7 @@ bd ready --limit 0
 bd list --status=in_progress
 bd blocked
 bd label list-all
-# For each epic:* label: bd list --label <label> --json
+# For each epic:* label: bd list --label <label> --json --all
 bd list --status=open --json | jq -r '.[].priority' | sort | uniq -c | sort -rn
 bd list --status=closed --limit 10
 ```

--- a/commands/team.md
+++ b/commands/team.md
@@ -93,7 +93,7 @@ Check:
 ### Step R4: Gather Context
 
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 cat "$ROOT/CLAUDE.md" 2>/dev/null | head -200
 
 # For each task:

--- a/docs/knowledge/gotchas.md
+++ b/docs/knowledge/gotchas.md
@@ -6,11 +6,13 @@ Things we discovered the hard way while building skills and workflows.
 
 **Problem:** Skills use bash code blocks as examples for Claude. If Claude's working directory changed (e.g., after `cd code/letsbrowse`), relative paths like `.lets/sessions/` resolve to wrong location.
 
-**Fix:** Always use `git rev-parse --show-toplevel` for repo-root-relative paths:
+**Fix:** Use `$ROOT` from LETS Config (injected by SessionStart hook as `project-root`):
 ```bash
-ROOT=$(git rev-parse --show-toplevel)
+# ROOT = project-root from LETS Config
 mkdir -p "$ROOT/.lets/sessions"
 ```
+
+In real bash scripts/hooks where LETS Config is not available, `git rev-parse --show-toplevel` is fine.
 
 **Affected:** `lets-end` (session file creation), `lets-start` (session file reading).
 

--- a/docs/knowledge/pr-review-lifecycle.md
+++ b/docs/knowledge/pr-review-lifecycle.md
@@ -156,7 +156,7 @@ Examples:
 
 ### Store drafts in beads
 
-As comments are refined, save them to the beads task via `bd update <id> --notes="..."`. This way the draft text survives context window compaction and session restarts.
+As comments are refined, save them to the beads task via `bd comments add <id> "..."`. This way the draft text survives context window compaction and session restarts.
 
 ---
 
@@ -366,7 +366,7 @@ bb-api pr comment <id> "LGTM. All critical issues resolved."
 
 ```bash
 # Update beads task
-bd update <task-id> --notes="Follow-up complete. PR #19 approved. ..."
+bd comments add <task-id> "Follow-up complete. PR #19 approved. ..."
 
 # If all PRs in the review are done
 bd close <task-id> --reason="All PRs reviewed and approved"
@@ -424,11 +424,11 @@ git diff <prev>..<fix>                      # Full fix diff
 # Create review task
 bd create --title="Code Review: PR #X, #Y - Feature name" --type=task --priority=1
 
-# Track posted comments in notes (after each comment)
-bd update <id> --notes="## Posted Comments Log ..."
+# Track posted comments (after each comment)
+bd comments add <id> "## Posted Comments Log ..."
 
 # Track follow-up
-bd update <id> --notes="## Follow-up Review ..."
+bd comments add <id> "## Follow-up Review ..."
 
 # Close when done
 bd close <id> --reason="All PRs reviewed and approved"

--- a/docs/knowledge/pr-review-posting-workflow.md
+++ b/docs/knowledge/pr-review-posting-workflow.md
@@ -143,7 +143,7 @@ Key differences from the old template:
 
 ## Tracking in Beads
 
-All posted comments are logged in the beads task via `bd update <task-id> --notes="..."`.
+All posted comments are logged in the beads task via `bd comments add <task-id> "..."`.
 
 ### Notes format
 

--- a/hooks/rules-context.md
+++ b/hooks/rules-context.md
@@ -14,7 +14,7 @@ These rules are injected by the LETS plugin and apply to every conversation.
 
 The SessionStart hook injects `## LETS Config` section above with project context and user settings. Use these values:
 
-- **`project-root`** - absolute path to project root. Use this instead of running `git rev-parse --show-toplevel`. Always available in git repos.
+- **`project-root`** - absolute path to project root. Use this instead of running `git rev-parse --show-toplevel`. Always available in git repos. In command bash snippets, use as `$ROOT`. Never run `git rev-parse --show-toplevel` to obtain the project root.
 - **`merge-branch`** - target branch for merges, PR base, and diff comparisons. Use this instead of hardcoded `main`. When running commands like `git log`, `git diff`, `git merge`, `git checkout -b` that need a base branch - use the configured value. Fallback: `git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null || echo main`.
 - **`language`** - default response language. Use this when user's language isn't clear from their message. Value is a full language name (English, Ukrainian, Italian, etc).
 - **`github`** - GitHub PR workflow mode (`true`/`false`, default `false`). When `true`: `/lets:done` pushes branch and creates PR via `gh pr create` instead of local merge, `/lets:status` shows open PRs. Requires `gh` CLI installed and authenticated (`gh auth login`). When `false` or missing: local merge workflow. Note: `github: false` means local merge even if a git remote exists - the config flag is the source of truth, not remote detection.

--- a/hooks/rules-context.md
+++ b/hooks/rules-context.md
@@ -14,7 +14,7 @@ These rules are injected by the LETS plugin and apply to every conversation.
 
 The SessionStart hook injects `## LETS Config` section above with project context and user settings. Use these values:
 
-- **`project-root`** - absolute path to project root. Use this instead of running `git rev-parse --show-toplevel`. Always available in git repos. In command bash snippets, use as `$ROOT`. Never run `git rev-parse --show-toplevel` to obtain the project root.
+- **`project-root`** - absolute path to project root. Prefer this over `git rev-parse --show-toplevel`. Always available in git repos. In command bash snippets, use as `$ROOT`. In real bash scripts/hooks where LETS Config is not injected, `git rev-parse --show-toplevel` is fine.
 - **`merge-branch`** - target branch for merges, PR base, and diff comparisons. Use this instead of hardcoded `main`. When running commands like `git log`, `git diff`, `git merge`, `git checkout -b` that need a base branch - use the configured value. Fallback: `git symbolic-ref refs/remotes/origin/HEAD --short 2>/dev/null || echo main`.
 - **`language`** - default response language. Use this when user's language isn't clear from their message. Value is a full language name (English, Ukrainian, Italian, etc).
 - **`github`** - GitHub PR workflow mode (`true`/`false`, default `false`). When `true`: `/lets:done` pushes branch and creates PR via `gh pr create` instead of local merge, `/lets:status` shows open PRs. Requires `gh` CLI installed and authenticated (`gh auth login`). When `false` or missing: local merge workflow. Note: `github: false` means local merge even if a git remote exists - the config flag is the source of truth, not remote detection.

--- a/hooks/rules-context.md
+++ b/hooks/rules-context.md
@@ -92,6 +92,10 @@ If you don't know the task title, run `bd show <id>` to get it.
 - Use `--labels epic:<name>` to group tasks by theme
 - Every `bd create` MUST include: `--title` (imperative mood), `--labels` (epic grouping), `--priority` (0-4), `--description` (why + acceptance criteria), `--type` (task/bug/feature/epic)
 
+### Updating Tasks
+
+- **Never use `bd update --notes` or `bd update --description` to append info** - these overwrite existing content. Use `bd comments add` for all incremental updates.
+
 ### Dependencies
 
 - Use `bd dep add` **sparingly** - only when task B literally cannot start without task A being done


### PR DESCRIPTION
## Summary

Batch of 8 quick-win fixes for the LETS plugin, implemented via /lets:team parallel agents.

### Batch 1: Bug fixes
- **Fix /lets:note** (`lets-1nynw`) - Replace `bd update --description` with `bd comments add [scope-change]` to prevent data loss
- **Worktree hint in /lets:end** (`lets-3x122`) - Show resume path when ending session in worktree
- **docs-expert in /lets:review** (`lets-w1lsp`) - Add LETS-specific doc sync checks to docs agent
- **Epic progress** (`lets-iazy3`) - Add `--all` flag to `bd list --label` for correct progress calculation

### Batch 2: Features + cleanup
- **--fast for /lets:end** (`lets-y386s`) - Quick session close that skips summary/sync
- **Session summaries in worktrees** (`lets-hvrti`) - Branch-specific summary files prevent overwrite
- **PR worktree guard** (`lets-2gcws`) - Skip `gh pr checkout` in worktrees, use `gh pr diff`
- **Remove git rev-parse** (`lets-duml2`) - Replace 28 occurrences with injected `project-root`

### Also fixed (from review)
- `docs/knowledge/pr-review-lifecycle.md` - Replace `bd update --notes` with `bd comments add` (5 places)
- `hooks/rules-context.md` - Add "never use --notes/--description to append" safety rule
- Strengthen project-root rule with explicit prohibition

## Changes
- 21 files changed
- 2 commits

## Test plan
- [ ] `/lets:end --fast` closes session quickly
- [ ] `/lets:end` in worktree shows resume path
- [ ] `/lets:start` reads branch-specific summary
- [ ] `/lets:status` shows correct epic progress
- [ ] `/lets:pr` in worktree doesn't switch branches
- [ ] `/lets:note` uses `bd comments add` for scope changes

Tasks: lets-1nynw, lets-3x122, lets-w1lsp, lets-iazy3, lets-y386s, lets-hvrti, lets-2gcws, lets-duml2