### PR TITLE
feat: Add ultrathink to review/analysis commands, update worktree open format

### DIFF
--- a/commands/ask.md
+++ b/commands/ask.md
@@ -100,7 +100,9 @@ Use the Task tool to spawn the selected agent:
 ```
 Task(
   subagent_type="lets:{agent-name}",
-  prompt="ASK MODE. A developer is asking you a direct question.
+  prompt="ultrathink
+
+ASK MODE. A developer is asking you a direct question.
 
 PROJECT CONTEXT:
 {CLAUDE.md summary - stack, conventions, key rules}

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -294,7 +294,9 @@ For each selected approach:
 ```
 Task(
   subagent_type="lets:architect",
-  prompt="DESIGN MODE: {approach name}.
+  prompt="ultrathink
+
+DESIGN MODE: {approach name}.
 
 Design a detailed architecture for this specific approach.
 
@@ -453,7 +455,9 @@ For each expert:
 ```
 Task(
   subagent_type="lets:{agent-name}",
-  prompt="OPINION MODE. Evaluate an architecture design for a feature.
+  prompt="ultrathink
+
+OPINION MODE. Evaluate an architecture design for a feature.
 
 FEATURE GOAL: {goal}
 

--- a/commands/check.md
+++ b/commands/check.md
@@ -49,6 +49,8 @@ cat "$ROOT/CLAUDE.md" 2>/dev/null | head -100
 
 ## Step 3: Review with 5 Lenses
 
+ultrathink
+
 Review the diff directly using these 5 perspectives. Think like a senior dev doing a quick PR scan - catch real issues, skip noise.
 
 ### [Bug] Bugs & Logic

--- a/commands/opinion.md
+++ b/commands/opinion.md
@@ -66,7 +66,9 @@ For each selected agent:
 ```
 Task(
   subagent_type="lets:{agent-name}",
-  prompt="OPINION MODE. Evaluate this technical decision.
+  prompt="ultrathink
+
+OPINION MODE. Evaluate this technical decision.
 
 PROJECT CONTEXT:
 {CLAUDE.md summary}

--- a/commands/review.md
+++ b/commands/review.md
@@ -203,6 +203,8 @@ For each selected agent, use the Task tool with:
 Each agent receives this context in their task prompt. Agents define their own expertise, confidence scoring, and output format in `agents/*.md` - do NOT duplicate those in the prompt.
 
 ```
+ultrathink
+
 Review the following code changes from your expert perspective.
 Use your confidence scoring system. Only report findings >= 80 confidence.
 Follow your output format as defined in your system prompt.
@@ -460,7 +462,9 @@ Always launch exactly 2 agents:
 ```
 Task(
   subagent_type="lets:architect",
-  prompt="PLAN REVIEW MODE. Review this implementation plan for quality and completeness.
+  prompt="ultrathink
+
+PLAN REVIEW MODE. Review this implementation plan for quality and completeness.
 
 PROJECT CONTEXT:
 {CLAUDE.md summary}
@@ -501,7 +505,9 @@ OUTPUT FORMAT:
 ```
 Task(
   subagent_type="lets:pragmatist",
-  prompt="PLAN REVIEW MODE. Review this implementation plan for feasibility and proportionality.
+  prompt="ultrathink
+
+PLAN REVIEW MODE. Review this implementation plan for feasibility and proportionality.
 
 PROJECT CONTEXT:
 {CLAUDE.md summary}

--- a/commands/start.md
+++ b/commands/start.md
@@ -134,7 +134,11 @@ AskUserQuestion(
 **Handle response:**
 - **Branch** -> `git checkout -b <branch> {merge-branch}` (standard flow, use `merge-branch` from LETS Config)
 - **Worktree** -> run `/lets:worktree create <task-id>-<slug>`, then inform:
-  "Worktree created at `.worktrees/<name>/`. Open a new terminal there and run `claude` -> `/lets:start`."
+  "Worktree created. Open a new terminal and run:"
+  ```bash
+  cd {absolute-worktree-path} && claude
+  ```
+  "Then use `/lets:start` to pick a task."
   Stop here - the worktree session continues in a separate terminal.
 
 ### Context Recovery (resuming existing branch)

--- a/commands/worktree.md
+++ b/commands/worktree.md
@@ -154,10 +154,11 @@ LETS: {symlinked / not available}
 
 Open a new terminal and run:
 
-  cd {absolute-worktree-path}
-  claude
+```bash
+cd {absolute-worktree-path} && claude
+```
 
-Then use /lets:start to pick a task and begin working.
+Then use `/lets:start` to pick a task and begin working.
 
 ┌─ LETS ─────────────────────────┐
 │  List?    /lets:worktree list  │

--- a/hooks/rules-context.md
+++ b/hooks/rules-context.md
@@ -124,7 +124,7 @@ GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 - Don't run `/lets:worktree create` from inside a worktree
 - Don't modify `.lets/` or `.beads/` structure (they're shared via symlink/redirect)
 
-**Lifecycle:** `/lets:worktree create <name>` (from main repo) -> open terminal in `.worktrees/<name>/` -> `claude` -> `/lets:start` -> work -> `/lets:done` -> `/lets:worktree remove <name>` (from main repo)
+**Lifecycle:** `/lets:worktree create <name>` (from main repo) -> new terminal: `cd .worktrees/<name>/ && claude` -> `/lets:start` -> work -> `/lets:done` -> `/lets:worktree remove <name>` (from main repo)
 
 ## Architecture Mindset
 
@@ -139,7 +139,7 @@ GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 github: false  /lets:start -> Work -> /lets:check -> /lets:commit -> /lets:done (merge) -> /lets:end
 github: true   /lets:start -> Work -> /lets:check -> /lets:commit -> /lets:done (push + PR) -> /lets:end
 
-Worktree:  /lets:worktree create -> terminal -> /lets:start -> Work -> /lets:done -> /lets:end -> /lets:worktree remove (main repo)
+Worktree:  /lets:worktree create -> `cd .worktrees/<name>/ && claude` -> /lets:start -> Work -> /lets:done -> /lets:end -> /lets:worktree remove (main repo)
 
 Team:      /lets:brainstorm -> /lets:team run -> monitor -> /lets:review --local -> /lets:done
 


### PR DESCRIPTION
## Summary

- Add `ultrathink` keyword to agent prompt templates for high-effort reasoning on Opus 4.6
- Update worktree open recommendation to single-line `cd path && claude` format

## Changes

- `commands/review.md` - ultrathink in code review + plan review agent prompts
- `commands/opinion.md` - ultrathink in expert agent prompts
- `commands/brainstorm.md` - ultrathink in architect + expert eval (NOT explorer)
- `commands/ask.md` - ultrathink in agent prompt
- `commands/check.md` - ultrathink in inline review section
- `commands/start.md` - updated worktree recommendation
- `commands/worktree.md` - single-line cd && claude format
- `hooks/rules-context.md` - updated worktree lifecycle (2 places)

## Tasks

- lets-afwa4: Add ultrathink to review and analysis commands (stays open - future scope)
- lets-6wqcq: Update worktree open recommendation (closed)

---
Generated with LETS plugin