### PR TITLE
feat: Add interactive exploration phase to plan, brainstorm, opinion

### DIFF
--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -9,6 +9,35 @@ Interactive backlog session. Review existing tasks, spot patterns, suggest prior
 
 **This command helps with WHAT to build. For HOW to build it, use `/lets:plan`.**
 
+## Step 0: Choose Mode
+
+If argument provided AND it's clearly an idea/topic (not an epic name), go directly to Explore mode.
+
+Otherwise ask:
+
+```
+AskUserQuestion(
+  questions=[{
+    question: "What would you like to do?",
+    header: "LETS",
+    options: [
+      { label: "Review backlog", description: "Review tasks, priorities, gaps, patterns" },
+      { label: "Explore idea", description: "Think through an idea together - questions, insights, trade-offs" }
+    ],
+    multiSelect: false
+  }]
+)
+```
+
+**Handle response:**
+- **Review backlog** -> proceed to Step 1 (Backlog mode)
+- **Explore idea** -> jump to Step E1 (Explore mode)
+- **Other** (free text) -> treat as topic for Explore mode
+
+---
+
+## Backlog Mode
+
 ## Step 1: Load Backlog Context
 
 ```bash
@@ -63,14 +92,14 @@ Enter conversational mode. No rigid steps - respond to what the user wants to di
 
 **When the conversation naturally ends** or user wants to move on, show the LETS box.
 
-## Rules
+## Rules (Backlog Mode)
 
 - **No agents** - this is a direct conversation
 - **No plan output** - if user wants structured planning, suggest `/lets:plan`
 - **All task mutations require user approval** - don't create/update tasks without asking
 - Respond in user's language (Ukrainian/Russian/English)
 
-## Output
+## Output (Backlog Mode)
 
 ```
 ┌─ LETS ──────────────────────────────────┐
@@ -78,3 +107,104 @@ Enter conversational mode. No rigid steps - respond to what the user wants to di
 │  Start work?   /lets:start             │
 └─────────────────────────────────────────┘
 ```
+
+---
+
+## Explore Mode
+
+Interactive exploration of an idea or concept. Ask probing questions, share insights, challenge assumptions. Build shared understanding before jumping to implementation.
+
+**This is a conversation, not a checklist.** One question or insight at a time.
+
+### Step E1: Capture Topic
+
+If argument provided: use it as topic.
+If not: ask "What idea or concept do you want to explore?"
+
+### Step E2: Open with Insights
+
+Start with 1-2 observations or connections, then ask the first probing question:
+
+```
+## Let's explore: {topic}
+
+**Insight:** {initial observation - what's interesting, non-obvious, or connected to something in the project}
+
+**Question:** {probing question that helps define scope or challenges an assumption}
+```
+
+### Step E3: Conversation Loop
+
+After each user response:
+
+1. **Acknowledge** - brief, no fluff ("Good point." / "That changes things.")
+2. **Build** - add an insight or connection based on their answer
+3. **Probe** - ask the next question that goes deeper or shifts angle
+
+### Question Types
+
+- **Assumption challenges:** "You're assuming X - what if Y instead?"
+- **Edge case probes:** "What happens when Z?"
+- **Trade-off surfacing:** "This gives you A but costs B - is that worth it?"
+- **Scope questions:** "Do you actually need X, or is Y enough for now?"
+- **User perspective:** "From the end user's view, what changes?"
+- **Feasibility:** "What's the simplest version of this that still delivers value?"
+- **Connections:** "This reminds me of {existing thing} - could we reuse/extend it?"
+
+### What Makes Good Insights
+
+- Connect dots between the idea and existing project patterns
+- Surface things that "almost exist" already
+- Flag decisions that are easy to change now but expensive later
+- Show non-obvious implications of a choice
+- Note when two goals conflict
+
+### Step E4: Exit & Capture
+
+Signals to wrap up:
+- User gives short answers (topic exhausted)
+- Key questions covered
+- User explicitly says "enough" / "let's move on"
+
+When wrapping up, summarize key findings:
+
+```
+## Exploration Summary
+
+**Topic:** {what we explored}
+
+**Key insights:**
+- {insight 1}
+- {insight 2}
+
+**Decisions made:**
+- {decision 1}
+
+**Open questions:**
+- {anything unresolved}
+```
+
+If active task exists, record to beads:
+
+```bash
+bd comments add <task-id> "Exploration: {topic}
+- {key insight 1}
+- {key insight 2}"
+```
+
+### Rules (Explore Mode)
+
+- **No agents** - direct conversation
+- **No code changes** - exploration produces understanding, not code
+- Respond in user's language
+
+### Output (Explore Mode)
+
+```
+┌─ LETS ─────────────────────────┐
+│  Plan?   /lets:plan            │
+│  Start?  /lets:start           │
+└────────────────────────────────┘
+```
+
+If exploration produced a clear task idea, ask: "Want me to create a task for this?" (plain text, not in LETS box).

--- a/commands/opinion.md
+++ b/commands/opinion.md
@@ -175,9 +175,55 @@ bd comments add <task-id> "Decision: {topic}. Chose: {recommended option}. Reaso
 4. **Reversible > Perfect** - can change later
 5. **Working > Elegant** - ship first, refactor later
 
+## Step 8: Discuss (opt-in)
+
+After presenting the recommendation, offer to explore it deeper:
+
+```
+AskUserQuestion(
+  questions=[{
+    question: "What's next?",
+    header: "LETS",
+    options: [
+      { label: "Discuss", description: "Explore the recommendation - questions, trade-offs, assumptions" },
+      { label: "Accept", description: "Recommendation is clear, move on" }
+    ],
+    multiSelect: false
+  }]
+)
+```
+
+**Handle response:**
+- **Discuss** -> enter exploration loop (see below)
+- **Accept** -> proceed to Output
+- **Other** (free text) -> treat as question about the recommendation
+
+### Exploration Loop
+
+Interactive discussion about the recommendation. One question/insight at a time.
+
+After each user response:
+1. **Acknowledge** - brief, no fluff
+2. **Build** - add an insight or connection based on their answer
+3. **Probe** - ask the next question that goes deeper
+
+Question types:
+- Challenge the recommendation: "The agents recommended X, but what about Y?"
+- Probe edge cases: "This works for the common case, but what happens when Z?"
+- Surface hidden trade-offs: "Option A is faster, but does it lock you into W?"
+- Connect to project context: "Given {existing pattern}, does this recommendation still hold?"
+
+When user is satisfied, proceed to Output.
+
+If active task exists, record the discussion outcome:
+
+```bash
+bd comments add <task-id> "Decision discussion: {topic}. Explored: {what was discussed}. Conclusion: {final stance}"
+```
+
 ## Output
 
-After recommendation, show LETS box based on context:
+After recommendation (or after discussion), show LETS box based on context:
 
 **If decision is about code changes:**
 ```

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -443,7 +443,7 @@ AskUserQuestion(
 **Handle response:**
 - **Recommended** -> dispatch recommended experts
 - **Pragmatist only** -> dispatch only pragmatist
-- **Skip evaluation** -> proceed directly to Step 8
+- **Skip evaluation** -> proceed directly to Step 9 (Plan Generation)
 - **Other** (free text) -> parse expert names from text, dispatch selected
 
 ### Dispatch Experts
@@ -507,9 +507,10 @@ Then:
 ```
 AskUserQuestion(
   questions=[{
-    question: "Proceed to plan generation?",
+    question: "How to proceed?",
     header: "LETS",
     options: [
+      { label: "Discuss", description: "Explore trade-offs, challenge assumptions, probe deeper" },
       { label: "Generate plan", description: "Architecture approved, write the implementation plan" },
       { label: "Adjust architecture", description: "Incorporate expert feedback first" }
     ],
@@ -519,11 +520,103 @@ AskUserQuestion(
 ```
 
 **Handle response:**
-- **Generate plan** -> proceed to Step 8
+- **Discuss** -> proceed to Step 8 (Interactive Exploration)
+- **Generate plan** -> skip to Step 9 (Plan Generation)
 - **Adjust architecture** -> discuss changes, update architecture, ask again
 - **Other** (free text) -> treat as adjustment request
 
-## Step 8: Plan Generation
+## Step 8: Interactive Exploration
+
+Deep-dive discussion to stress-test the architecture before committing to a plan. Ask probing questions, share insights, challenge assumptions.
+
+**This step is opt-in** - user chooses "Discuss" after evaluation. For simple tasks users skip straight to plan generation.
+
+### How It Works
+
+This is a **conversation, not a checklist**. One question or insight at a time, building on user's responses.
+
+### Start with Insights
+
+Open with 2-3 insights derived from exploration + evaluation. Format:
+
+```
+## Let's explore this deeper
+
+**Insight:** {non-obvious implication from the architecture or expert feedback}
+
+**Insight:** {connection the user might not have considered - "X already almost exists because Y"}
+
+**Question:** {probing question that challenges an assumption or surfaces a trade-off}
+```
+
+### Conversation Loop
+
+After each user response:
+
+1. **Acknowledge** - brief, no fluff ("Good point." / "That changes things.")
+2. **Build** - add an insight or connection based on their answer
+3. **Probe** - ask the next question that goes deeper or shifts angle
+
+### Question Types to Draw From
+
+- **Assumption challenges:** "You're assuming X - what if Y instead?"
+- **Edge case probes:** "What happens when Z?"
+- **Trade-off surfacing:** "This gives you A but costs B - is that worth it?"
+- **Scope questions:** "Do you actually need X, or is Y enough for now?"
+- **Integration risks:** "How does this interact with {existing thing from exploration}?"
+- **Future-proofing:** "If requirements change to include X, does this design bend or break?"
+- **User perspective:** "From the end user's view, what changes?"
+
+### What Makes Good Insights
+
+- Connect dots between exploration findings and user's goals
+- Surface things that "almost exist" in the codebase
+- Flag where the architecture diverges from existing patterns (and whether that's intentional)
+- Note when expert feedback contradicts each other
+- Highlight decisions that are easy to change now but expensive later
+
+### Exit Condition
+
+After each exchange, gauge whether to continue or wrap up. Signals to wrap up:
+- User gives short answers (topic exhausted)
+- Key questions have been covered
+- User explicitly says "enough" / "let's move on"
+
+When ready to wrap up:
+
+```
+AskUserQuestion(
+  questions=[{
+    question: "Ready to generate the plan?",
+    header: "LETS",
+    options: [
+      { label: "Generate plan", description: "Discussion complete, write the implementation plan" },
+      { label: "Keep exploring", description: "More to discuss" },
+      { label: "Adjust architecture", description: "Change the approach based on what we discussed" }
+    ],
+    multiSelect: false
+  }]
+)
+```
+
+**Handle response:**
+- **Generate plan** -> proceed to Step 9
+- **Keep exploring** -> continue conversation loop
+- **Adjust architecture** -> go back to Step 6 with updated context from discussion
+- **Other** (free text) -> treat as continuation of discussion
+
+### Record Key Findings
+
+After exploration ends, if active task exists:
+
+```bash
+bd comments add <task-id> "Exploration insights:
+- {key insight 1}
+- {key insight 2}
+- {decision or trade-off confirmed}"
+```
+
+## Step 9: Plan Generation
 
 Write a detailed implementation plan for the chosen architecture.
 
@@ -608,7 +701,7 @@ Before saving, verify the plan passes these gates:
 - Every logical unit has a commit point
 - File paths are exact and verified against explorer findings
 
-## Step 9: Save & Output
+## Step 10: Save & Output
 
 ### Save Plan
 


### PR DESCRIPTION
## Summary
- `/lets:plan` Step 8: Interactive exploration after expert evaluation (opt-in "Discuss" option)
- `/lets:brainstorm` Explore mode: Step 0 choice between backlog review and idea exploration
- `/lets:opinion` Step 8: Discuss option after recommendation to probe trade-offs

All three share the same conversation loop pattern: insights -> probing questions -> acknowledge/build/probe -> exit when ready.

## Changes
- a19c3ce feat: Add interactive exploration phase to /lets:plan
- 3a8589d feat: Add exploration mode to brainstorm and opinion

## Task
lets-uzaly: Add interactive exploration phase to /lets:plan

---
Generated with LETS plugin