### PR TITLE
feat: Redesign /lets:brainstorm with 4 modes and parallel agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Claude Code plugin for development workflow with session management, code review
 ```
 .claude-plugin/plugin.json   # Plugin manifest
 commands/                     # Slash commands (/lets:start, /lets:done, /lets:review, etc.)
-agents/                       # Expert agents (review, opinion, ask, plan, team implementation)
+agents/                       # Expert agents (review, opinion, ask, plan, brainstorm, team implementation)
 hooks/                        # SessionStart hook, workflow rules, config template
 scripts/lets/                 # Statusline + init script (copied/run per-project by /lets:init)
 reference/                    # Reference plugins for studying patterns (gitignored)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ reference/                    # Reference plugins for studying patterns (gitigno
 ## Key Concepts
 
 - **Commands** = user-initiated workflows (sessions, commits, reviews)
-- **Agents** = experts dispatched by commands. `/lets:review`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:team` use specialized agents
+- **Agents** = experts dispatched by commands. `/lets:review`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:team`, `/lets:brainstorm` use specialized agents
 - **Orchestrators** = commands that delegate to other commands. `/lets:pr` orchestrates `/lets:review` for full PR lifecycle
 - **Hooks** = SessionStart injects workflow rules
 - **Statusline** = per-project `.lets/statusline.sh`, source in `scripts/lets/statusline.sh`, copied by `/lets:init`
@@ -24,7 +24,7 @@ reference/                    # Reference plugins for studying patterns (gitigno
 ## Architecture Decisions
 
 - Agents define WHO (expertise, scoring, output format). Commands define WHAT to do (provide diff, context)
-- `/lets:review`, `/lets:opinion`, `/lets:ask`, `/lets:plan` use `subagent_type: "lets:agent-name"` to dispatch agents via Task tool
+- `/lets:review`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:brainstorm` use `subagent_type: "lets:agent-name"` to dispatch agents via Task tool
 - `/lets:pr` orchestrates `/lets:review` (delegates analysis) and handles GitHub posting, follow-up, respond, and approval directly via gh CLI
 - `/lets:execute` uses EnterPlanMode for native plan mode execution with user approval gates. No subagents.
 - `/lets:check` reviews inline (no subagent) for speed

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,5 +1,5 @@
 ---
-description: Interactive ideation - review backlog with agents, explore ideas, quick brainstorm, cleanup stale tasks
+description: Interactive ideation - review backlog, explore ideas, quick brainstorm, cleanup
 argument-hint: "[topic or epic name]"
 ---
 
@@ -166,7 +166,11 @@ Mandatory agent context (append to prompt based on agent):
 |-------|-----------------|
 | pragmatist | "Focus on ROI. Which ideas deliver the most value for least effort? Flag overengineering or premature optimization." |
 | architect | "Focus on structural opportunities. Where could the system be simplified, better decomposed, or made more extensible?" |
+| backend | "Focus on API gaps, performance bottlenecks, and missing error handling. What backend patterns could be improved?" |
+| frontend | "Focus on UX gaps, component reuse opportunities, and accessibility. What frontend patterns need attention?" |
 | security | "Focus on security debt and missing protections. What attack surfaces are unprotected?" |
+| database | "Focus on schema evolution opportunities, query patterns that could be simplified, and data model gaps." |
+| devops | "Focus on CI/CD gaps, deployment friction, and infrastructure debt. What automation is missing?" |
 | docs | "Focus on documentation debt. What's undocumented, stale, or missing for onboarding?" |
 | qa | "Focus on quality gaps. What's untested? Where would tests catch real bugs?" |
 
@@ -256,7 +260,7 @@ DIALOG_QUESTION = "What catches your eye?"
 ```
 "ultrathink
 
-BRAINSTORM SCOUT MODE. Gather project context for a brainstorm session.
+BRAINSTORM SCOUT MODE. In this mode, your mapping role extends to surfacing signals and gaps - not just structure. Gather project context for a brainstorm session.
 
 RESPONSE LANGUAGE: {language from LETS Config}
 PROJECT ROOT: {project-root from LETS Config}. Do NOT read or search files outside this directory.
@@ -338,6 +342,9 @@ BRAINSTORM MODE. Generate ideas and surface gaps from your area of expertise.
 You are NOT reviewing code or evaluating a decision. You are looking at a project's
 current state and generating actionable insights about what to build, fix, or improve.
 
+PROJECT RULES (from CLAUDE.md):
+{CLAUDE.md summary, first 100 lines - architecture decisions and structure}
+
 PROJECT STATE PROFILE:
 {explorer output from Phase 1}
 
@@ -393,7 +400,7 @@ DIALOG_QUESTION = "What resonates?"
 ```
 "ultrathink
 
-BRAINSTORM SCOUT MODE. Gather project context relevant to a specific topic.
+BRAINSTORM SCOUT MODE. In this mode, your mapping role extends to surfacing signals and gaps - not just structure. Gather project context relevant to a specific topic.
 
 RESPONSE LANGUAGE: {language from LETS Config}
 PROJECT ROOT: {project-root from LETS Config}. Do NOT read or search files outside this directory.
@@ -464,6 +471,9 @@ an idea and generating insights, questions, and angles from your domain.
 
 TOPIC: {user's topic}
 
+PROJECT RULES (from CLAUDE.md):
+{CLAUDE.md summary, first 100 lines - architecture decisions and structure}
+
 TOPIC CONTEXT PROFILE:
 {explorer output from Phase 1}
 
@@ -509,7 +519,11 @@ bd stats
 bd list --status=open -n 30
 bd list --status=in_progress
 git log --oneline -15
-grep -rn "TODO\|FIXME\|HACK\|XXX" --include="*.md" --include="*.ts" --include="*.py" --include="*.php" --include="*.go" --include="*.js" --include="*.sh" "$ROOT" 2>/dev/null | head -20
+```
+
+Also use Grep tool (not bash grep) to scan for tech debt signals:
+```
+Grep(pattern="TODO|FIXME|HACK|XXX", path="$ROOT", output_mode="content", head_limit=20)
 ```
 
 If argument provided (topic/epic):
@@ -661,7 +675,7 @@ bd comments add <task-id> "Cleanup: closed {N}, reprioritized {M}"
 ┌─ LETS ──────────────────────────────────┐
 │  Go deeper?  /lets:brainstorm           │
 │  Plan?       /lets:plan                 │
-│  Start?      /lets:start               │
+│  Start?      /lets:start                │
 └─────────────────────────────────────────┘
 ```
 

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -585,6 +585,7 @@ No agents. Direct interactive triage of stale/messy backlog items.
 bd stats
 bd list --status=open -n 50
 bd list --status=done -n 20
+bd label list 2>/dev/null
 ```
 
 ### Step C2: Present Cleanup Targets
@@ -608,6 +609,14 @@ Analyze loaded data and group:
 
 ### Done but Not Closed
 - **{title}** (`id`) - status done
+...
+
+### Orphan Tasks (no labels/epic grouping)
+- **{title}** (`id`) - no labels, suggest: epic:{suggestion based on title}
+...
+
+### Unassigned Tasks (open, no assignee)
+- **{title}** (`id`) - P{N}, suggest assignee based on domain
 ...
 ```
 
@@ -637,6 +646,12 @@ For closing:
 - `bd close <id>`
 - If closing as duplicate: `bd comments add <other-id> "Absorbed from {closed-id}: {title}"` then `bd close <id>`
 
+For orphan tasks (no labels), suggest a label and ask:
+- `bd label add <id> epic:{name}` - assign to epic
+
+For unassigned tasks, suggest an assignee based on task domain and ask:
+- `bd update <id> --assignee={name}` - assign to person
+
 All mutations require user approval.
 Continue until all groups processed or user says "enough".
 
@@ -647,13 +662,15 @@ Continue until all groups processed or user says "enough".
 
 - Closed: {N} tasks
 - Reprioritized: {M} tasks
+- Labeled: {L} tasks
+- Assigned: {A} tasks
 - Skipped: {K} tasks
 ```
 
 If active task:
 
 ```bash
-bd comments add <task-id> "Cleanup: closed {N}, reprioritized {M}"
+bd comments add <task-id> "Cleanup: closed {N}, reprioritized {M}, labeled {L}, assigned {A}"
 ```
 
 ---

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -1,17 +1,17 @@
 ---
-description: Interactive backlog helper - review tasks, suggest priorities, spot patterns, create tasks
+description: Interactive ideation - review backlog with agents, explore ideas, quick brainstorm, cleanup stale tasks
 argument-hint: "[topic or epic name]"
 ---
 
 # Brainstorm
 
-Interactive backlog session. Review existing tasks, spot patterns, suggest priorities, create new tasks. No agents - this is a conversation between you and the user about what to build.
+Interactive ideation with 4 modes. Heavy modes launch explorer + parallel agents for multi-perspective insights. Light modes work instantly.
 
 **This command helps with WHAT to build. For HOW to build it, use `/lets:plan`.**
 
 ## Step 0: Choose Mode
 
-If argument provided AND it's clearly an idea/topic (not an epic name), go directly to Explore mode.
+If argument provided AND it's clearly an idea/topic (not an epic name), go directly to Explore idea mode.
 
 Otherwise ask:
 
@@ -19,10 +19,12 @@ Otherwise ask:
 AskUserQuestion(
   questions=[{
     question: "What would you like to do?",
-    header: "LETS",
+    header: "Brainstorm",
     options: [
-      { label: "Review backlog", description: "Review tasks, priorities, gaps, patterns" },
-      { label: "Explore idea", description: "Think through an idea together - questions, insights, trade-offs" }
+      { label: "Review backlog", description: "Agents analyze project state, generate ideas and surface gaps (~2-3 min)" },
+      { label: "Explore idea", description: "Agents research a topic from different angles (~2-3 min)" },
+      { label: "Quick brainstorm", description: "Fast context scan, direct conversation - no agents" },
+      { label: "Cleanup", description: "Triage stale tasks - close, merge, reprioritize" }
     ],
     multiSelect: false
   }]
@@ -30,181 +32,654 @@ AskUserQuestion(
 ```
 
 **Handle response:**
-- **Review backlog** -> proceed to Step 1 (Backlog mode)
-- **Explore idea** -> jump to Step E1 (Explore mode)
-- **Other** (free text) -> treat as topic for Explore mode
+- **Review backlog** -> set mode variables (Step R0), then Heavy Mode Flow
+- **Explore idea** -> set mode variables (Step E0), then Heavy Mode Flow
+- **Quick brainstorm** -> Step Q1
+- **Cleanup** -> Step C1
+- **Other** (free text) -> treat as topic for Explore idea mode
 
 ---
 
-## Backlog Mode
+## Heavy Mode Flow
 
-## Step 1: Load Backlog Context
+Shared flow for Review backlog and Explore idea modes. Each mode sets variables before entering this flow.
+
+**Mode variables** (set by calling mode before entering flow):
+- `{MODE_NAME}`: "Review backlog" or "Explore idea"
+- `{EXPLORER_PROMPT}`: mode-specific explorer prompt (see Step R0 / Step E0)
+- `{AGENT_PROMPT_TEMPLATE}`: mode-specific prompt for brainstorm agents
+- `{FORCED_AGENT}`: agent always included (pragmatist for backlog, architect for explore)
+- `{DIALOG_QUESTION}`: mode-specific dialog question text
+
+### Phase 1: Explorer - Gather Context
+
+Launch explorer to build a context profile.
+
+```
+Task(
+  subagent_type="lets:explorer",
+  prompt="{EXPLORER_PROMPT}"
+)
+```
+
+#### Explorer Failure Guard
+
+If explorer fails, times out, or returns no structured profile:
+
+> "Explorer couldn't gather context. Switching to Quick brainstorm."
+
+Jump to Step Q1 (Quick brainstorm mode).
+
+#### Thin Profile Guard
+
+After explorer returns, check task count from profile's Backlog Summary section.
+
+If < 5 open tasks reported:
+
+> "Project has very few tasks - not enough context for multi-agent analysis. Switching to Quick brainstorm."
+
+Jump to Step Q1 (Quick brainstorm mode).
+
+### Phase 2: Select Brainstorm Agents
+
+Command analyzes the explorer profile and selects agents. Do NOT ask the explorer to recommend agents - explorer maps, command decides.
+
+**Selection logic:**
+
+Scan the profile for signals and match to agents:
+
+| Signal in Profile | Select Agent |
+|-------------------|-------------|
+| API/endpoint/backend mentions, backend-heavy code | backend |
+| UI/frontend/component mentions | frontend |
+| Auth/security/credentials/secrets mentions | security |
+| Database/schema/migration mentions | database |
+| Docker/CI/deploy/infrastructure mentions | devops |
+| Test/coverage/quality mentions | qa |
+| Docs/README/onboarding mentions | docs |
+| Module boundaries, coupling, architecture patterns | architect |
+| Many tasks, mixed priorities, scope questions | pragmatist |
+
+**Rules:**
+1. Always include `{FORCED_AGENT}` (pragmatist for backlog, architect for explore)
+2. Select agents matching signals found in profile
+3. Cap at 5 agents total, minimum 3
+4. If fewer than 3 signals matched, pad with architect + pragmatist
+
+**Agent eligibility:**
+
+| Agent | Eligible | Brainstorm Strength |
+|-------|----------|-------------------|
+| architect | Yes | System gaps, module boundaries, structural opportunities |
+| pragmatist | Yes | ROI, what to cut, what to prioritize |
+| backend | Yes | API gaps, performance bottlenecks |
+| frontend | Yes | UX gaps, component patterns |
+| security | Yes | Security debt, missing protections |
+| database | Yes | Schema evolution, query patterns |
+| devops | Yes | CI/CD gaps, infrastructure debt |
+| qa | Yes | Testing gaps, coverage holes |
+| docs | Yes | Documentation debt, onboarding gaps |
+| compliance | No | Rule-checking, not ideation |
+| git-historian | No | Historical analysis, not forward-looking |
+| implementer | No | Has write access, wrong mode |
+| explorer | No | Already used in phase 1 |
+
+Show selection before launching (no user gate - brainstorm = momentum):
+
+```
+## Brainstorm Panel
+
+Based on project context, selected {N} experts:
+1. {agent} - {signal that triggered selection}
+2. {agent} - {signal}
+...
+
+Launching...
+```
+
+### Phase 3: Launch Brainstorm Agents (Parallel)
+
+CRITICAL: Launch ALL selected agents in a SINGLE message with multiple Task tool calls.
+
+For each selected agent:
+
+```
+Task(
+  subagent_type="lets:{agent-name}",
+  prompt="{AGENT_PROMPT_TEMPLATE}"
+)
+```
+
+The prompt template is set by the calling mode (Step R0 or Step E0). Both templates share this structure:
+
+- ultrathink prefix
+- RESPONSE LANGUAGE + PROJECT ROOT
+- BRAINSTORM MODE header (review or explore variant)
+- Context profile from explorer (keep concise - pass summary, not raw data)
+- Instructions specific to the mode
+- Mandatory agent context from table below
+- Output format
+
+Mandatory agent context (append to prompt based on agent):
+
+| Agent | Append to prompt |
+|-------|-----------------|
+| pragmatist | "Focus on ROI. Which ideas deliver the most value for least effort? Flag overengineering or premature optimization." |
+| architect | "Focus on structural opportunities. Where could the system be simplified, better decomposed, or made more extensible?" |
+| security | "Focus on security debt and missing protections. What attack surfaces are unprotected?" |
+| docs | "Focus on documentation debt. What's undocumented, stale, or missing for onboarding?" |
+| qa | "Focus on quality gaps. What's untested? Where would tests catch real bugs?" |
+
+### Phase 4: Aggregate & Present
+
+After all agents respond:
+
+1. Group ideas by impact (high first)
+2. Deduplicate: if two agents suggest the same area, merge and note both perspectives
+3. Separate: Top Ideas / Gaps / Quick Wins
+
+```
+## Brainstorm Results
+
+{N} ideas from {M} experts.
+
+### High Impact
+1. **{idea}** ({agent}) - {one-liner}
+2. **{idea}** ({agents if merged}) - {one-liner}
+...
+
+### Medium Impact
+1. **{idea}** ({agent}) - {one-liner}
+...
+
+### Gaps Identified
+- {gap} ({agent})
+...
+
+### Quick Wins
+- {quick win} ({agent})
+...
+```
+
+### Phase 5: Interactive Dialog
+
+```
+AskUserQuestion(
+  questions=[{
+    question: "{DIALOG_QUESTION}",
+    header: "Brainstorm",
+    options: [
+      { label: "Explore an idea", description: "Dig deeper into a specific idea or insight" },
+      { label: "Create tasks", description: "Turn selected ideas into backlog tasks" },
+      { label: "Done", description: "Enough for now" }
+    ],
+    multiSelect: false
+  }]
+)
+```
+
+**Handle response:**
+- **Explore an idea** -> ask which one, enter conversation loop (acknowledge, build, probe)
+- **Create tasks** -> ask which ideas, use `bd create` with user approval per task
+- **Done** -> Phase 6
+- **Free text** -> treat as exploring a specific idea
+
+Dialog continues until user signals done.
+
+### Phase 6: Capture & Exit
+
+If active task:
+
+```bash
+bd comments add <task-id> "Brainstorm ({MODE_NAME}): {N} ideas from {M} agents.
+Top ideas: {top 2-3 titles}
+Tasks created: {list or 'none'}"
+```
+
+If exploration produced a clear task idea but none created, ask:
+"Want me to create a task for this?" (plain text, not in LETS box).
+
+---
+
+## Review Backlog Mode
+
+### Step R0: Set Mode Variables
+
+```
+MODE_NAME = "review backlog"
+FORCED_AGENT = pragmatist
+DIALOG_QUESTION = "What catches your eye?"
+```
+
+**EXPLORER_PROMPT:**
+
+```
+"ultrathink
+
+BRAINSTORM SCOUT MODE. Gather project context for a brainstorm session.
+
+RESPONSE LANGUAGE: {language from LETS Config}
+PROJECT ROOT: {project-root from LETS Config}. Do NOT read or search files outside this directory.
+
+GOAL: Build a Project State Profile for brainstorming. We need to understand
+what the project is, what work has been done, what's planned, and where gaps exist.
+
+AVAILABLE CONTEXT SOURCES (read what's relevant, skip what's not):
+
+1. BACKLOG STATE
+   Run: bd stats
+   Run: bd list --status=open -n 50
+   Run: bd list --status=in_progress
+   Run: bd list --status=done -n 20
+   Purpose: understand task distribution, priorities, what's active
+
+2. TASK DETAILS (selective - pick 5-10 most interesting tasks)
+   Run: bd show <task-id>
+   Run: bd comments <task-id>
+   Purpose: understand context, decisions, blockers on key tasks
+
+3. RECENT SESSION SUMMARIES
+   Read: .lets/sessions/*.md (most recent 3-5 files by name)
+   Purpose: what was worked on recently, what momentum exists
+
+4. CODEBASE SIGNALS
+   Grep for: TODO, FIXME, HACK, XXX across source files
+   Read: CLAUDE.md (project structure and architecture)
+   Purpose: understand technical debt signals and project shape
+
+5. RECENT GIT ACTIVITY
+   Run: git log --oneline -20
+   Run: git log --oneline --since='2 weeks ago' --format='%s'
+   Purpose: what areas are actively changing
+
+BUDGET: Be efficient. Read backlog first (sources 1-2), then decide which
+of sources 3-5 add value. If backlog is rich (50+ tasks with comments),
+you can skip session summaries. If backlog is sparse, lean more on git
+and codebase signals.
+
+Keep output concise - max ~500 words. This profile will be passed to multiple agents.
+
+OUTPUT FORMAT - Project State Profile:
+
+## Project State Profile
+
+### Project Shape
+{what this project is, tech stack, size - from CLAUDE.md}
+
+### Backlog Summary
+- Open: {N} tasks
+- In progress: {N}
+- Done recently: {N}
+- By area/label: {breakdown if labels exist}
+
+### Active Momentum
+{what's being worked on now, what sessions focused on recently}
+
+### Hot Areas
+{parts of codebase with most recent activity - files, modules}
+
+### Gaps & Signals
+- Missing coverage: {areas with no tasks but active code}
+- Stale tasks: {tasks open for a long time with no activity}
+- TODOs in code: {count and themes}
+- Recurring themes: {patterns across tasks/comments/sessions}"
+```
+
+**AGENT_PROMPT_TEMPLATE:**
+
+```
+"ultrathink
+
+RESPONSE LANGUAGE: {language from LETS Config}
+PROJECT ROOT: {project-root from LETS Config}. Do NOT read or search files outside this directory.
+
+BRAINSTORM MODE. Generate ideas and surface gaps from your area of expertise.
+
+You are NOT reviewing code or evaluating a decision. You are looking at a project's
+current state and generating actionable insights about what to build, fix, or improve.
+
+PROJECT STATE PROFILE:
+{explorer output from Phase 1}
+
+INSTRUCTIONS:
+- Scan the project from YOUR expertise lens
+- Read files in areas relevant to your domain if needed (you have Read/Grep/Glob)
+- Generate 3-7 ideas: things to build, improve, fix, or investigate
+- Each idea must be specific and actionable (not vague like 'improve testing')
+- Prioritize ideas by impact (high/medium)
+- Flag gaps: areas with no tasks but clear need from your perspective
+- Connect to existing tasks when relevant ('task X could be extended to also cover Y')
+- Be opinionated - rank and recommend, don't just list
+
+{mandatory agent context}
+
+OUTPUT FORMAT:
+
+## {Your Domain} Perspective
+
+### Top Ideas
+1. **{idea title}** [Impact: high/medium]
+   {2-3 sentences: what, why it matters, rough scope}
+   {connection to existing task if any}
+
+### Gaps I See
+- {gap}: {why this matters from your expertise}
+
+### Quick Wins
+- {small improvement that could be done in one session}"
+```
+
+Then enter Heavy Mode Flow (Phase 1).
+
+---
+
+## Explore Idea Mode
+
+### Step E0: Capture Topic & Set Mode Variables
+
+If argument provided: use it as topic.
+If not: ask "What idea or topic do you want to explore?"
+
+Wait for answer before proceeding.
+
+```
+MODE_NAME = "explore: {topic}"
+FORCED_AGENT = architect
+DIALOG_QUESTION = "What resonates?"
+```
+
+**EXPLORER_PROMPT:**
+
+```
+"ultrathink
+
+BRAINSTORM SCOUT MODE. Gather project context relevant to a specific topic.
+
+RESPONSE LANGUAGE: {language from LETS Config}
+PROJECT ROOT: {project-root from LETS Config}. Do NOT read or search files outside this directory.
+
+TOPIC: {user's topic}
+
+AVAILABLE CONTEXT SOURCES (read what's relevant to this topic):
+
+1. RELATED TASKS
+   Run: bd search {topic keywords}
+   Run: bd list --status=open -n 30
+   Purpose: find tasks related to this topic
+   Note: if bd search returns no results, fall back to bd list and scan titles manually
+
+2. TASK DETAILS (for related tasks found above)
+   Run: bd show <task-id>
+   Run: bd comments <task-id>
+   Purpose: understand existing thinking on this topic
+
+3. RELATED CODE
+   Grep for: {topic keywords} across source files
+   Glob for: files in areas related to the topic
+   Read: key files that relate to the idea
+   Purpose: understand what exists already
+
+4. PROJECT CONTEXT
+   Read: CLAUDE.md
+   Purpose: understand where this topic fits in the project
+
+5. SESSION HISTORY
+   Read: .lets/sessions/*.md (scan for topic mentions)
+   Purpose: has this been discussed before?
+
+BUDGET: Focus on sources 1-3. Source 4 is always worth reading.
+Source 5 only if sources 1-2 are sparse.
+
+Keep output concise - max ~500 words. This profile will be passed to multiple agents.
+
+OUTPUT FORMAT - Topic Context Profile:
+
+## Topic Context Profile: {topic}
+
+### What Exists Already
+{code, tasks, or prior work related to this topic}
+
+### Related Tasks
+{list of tasks touching this area, with status}
+
+### Prior Discussions
+{anything from task comments or sessions about this topic}
+
+### Codebase Touchpoints
+{files and modules this topic would affect}"
+```
+
+**AGENT_PROMPT_TEMPLATE:**
+
+```
+"ultrathink
+
+RESPONSE LANGUAGE: {language from LETS Config}
+PROJECT ROOT: {project-root from LETS Config}. Do NOT read or search files outside this directory.
+
+BRAINSTORM MODE. Explore a specific topic from your area of expertise.
+
+You are NOT reviewing code or evaluating a decision. You are thinking through
+an idea and generating insights, questions, and angles from your domain.
+
+TOPIC: {user's topic}
+
+TOPIC CONTEXT PROFILE:
+{explorer output from Phase 1}
+
+INSTRUCTIONS:
+- Think about this topic through YOUR expertise lens
+- Read relevant code if needed to ground your thinking
+- Generate 2-4 insights: non-obvious angles, risks, opportunities
+- Surface questions the user should answer before proceeding
+- Suggest approaches or patterns from your domain that apply
+- If this topic has been partially explored before (see context), build on it
+- Be specific to THIS project, not generic advice
+
+{mandatory agent context}
+
+OUTPUT FORMAT:
+
+## {Your Domain} Perspective on: {topic}
+
+### Insights
+1. **{insight}**
+   {2-3 sentences: why this matters, how it connects}
+
+### Questions to Consider
+- {question from your domain perspective}
+
+### Suggested Approach
+{concrete recommendation for how to approach this topic from your domain}"
+```
+
+Then enter Heavy Mode Flow (Phase 1).
+
+---
+
+## Quick Brainstorm Mode
+
+No agents. Command gathers context directly and enters conversation.
+
+### Step Q1: Gather Context
 
 ```bash
 # ROOT = project-root from LETS Config
 bd stats
 bd list --status=open -n 30
+bd list --status=in_progress
+git log --oneline -15
+grep -rn "TODO\|FIXME\|HACK\|XXX" --include="*.md" --include="*.ts" --include="*.py" --include="*.php" --include="*.go" --include="*.js" --include="*.sh" "$ROOT" 2>/dev/null | head -20
 ```
 
-If argument provided:
-- If it matches an epic label: `bd list --labels epic:<argument>`
-- Otherwise: `bd search <argument>` to find relevant tasks
+If argument provided (topic/epic):
+- `bd search {argument}` (if no results, fall back to `bd list` and scan titles)
+- Grep/Glob for related code
 
-## Step 2: Present Overview
+### Step Q2: Open with Insights
 
-Show a compact backlog summary:
-
-```
-## Backlog Overview
-
-**Stats:** {open} open, {in_progress} in progress, {blocked} blocked
-
-### By Epic
-- **{epic name}**: {N} tasks ({M} open, {K} done)
-- ...
-
-### Ready to Work
-{top 5 from bd ready, with priority}
-
-### In Progress
-{from bd list --status=in_progress}
-```
-
-If argument was provided, focus the overview on that topic/epic.
-
-## Step 3: Interactive Discussion
-
-Enter conversational mode. No rigid steps - respond to what the user wants to discuss.
-
-**Things you can help with:**
-- **Prioritization**: Review task priorities, suggest reordering
-- **Gap analysis**: What's missing? What epics need more tasks?
-- **Pattern spotting**: Similar tasks that could be grouped, duplicate work
-- **Task creation**: Help formulate new tasks with proper title, description, labels, priority
-- **Epic planning**: Review epic scope, suggest breakdown
-- **Project insights**: Trends, bottleneck identification, velocity observations
-- **Cleanup**: Find stale tasks, outdated priorities, tasks that can be closed
-
-**When creating tasks:**
-- Always use `bd create` with full parameters: `--title`, `--description`, `--type`, `--priority`, `--labels`
-- Ask user for approval before creating
-- Suggest epic labels for grouping
-
-**When the conversation naturally ends** or user wants to move on, show the LETS box.
-
-## Rules (Backlog Mode)
-
-- **No agents** - this is a direct conversation
-- **No plan output** - if user wants structured planning, suggest `/lets:plan`
-- **All task mutations require user approval** - don't create/update tasks without asking
-- Respond in user's language (Ukrainian/Russian/English)
-
-## Output (Backlog Mode)
+Based on gathered context, present 3-5 proactive observations:
 
 ```
-┌─ LETS ──────────────────────────────────┐
-│  Plan a task?  /lets:plan              │
-│  Start work?   /lets:start             │
-└─────────────────────────────────────────┘
+## Quick Brainstorm
+
+Based on what I see in the project:
+
+1. **{observation}** - {why it matters, 1-2 sentences}
+2. **{observation}** - {why it matters}
+3. **{observation}** - {why it matters}
+
+**Question:** {probing question that opens discussion}
+```
+
+Categories to draw observations from:
+- Gaps: areas with activity but no tasks
+- Stale work: tasks open long with no progress
+- Patterns: recurring themes across tasks/commits
+- Quick wins: small improvements with high impact
+- Risks: things that could break or become debt
+
+### Step Q3: Interactive Dialog
+
+After each user response:
+1. **Acknowledge** - brief, no fluff
+2. **Build** - add insight or connection
+3. **Probe** - ask next question that goes deeper
+
+If user wants deeper expert analysis, suggest:
+"Want to go deeper? `/lets:brainstorm` (Review backlog) launches expert agents."
+
+### Step Q4: Capture & Exit
+
+If active task:
+
+```bash
+bd comments add <task-id> "Quick brainstorm: {key takeaways, 2-3 items}"
+```
+
+If ideas emerged that deserve tasks, offer to create them.
+
+---
+
+## Cleanup Mode
+
+No agents. Direct interactive triage of stale/messy backlog items.
+
+### Step C1: Load Backlog
+
+```bash
+bd stats
+bd list --status=open -n 50
+bd list --status=done -n 20
+```
+
+### Step C2: Present Cleanup Targets
+
+Analyze loaded data and group:
+
+```
+## Cleanup Targets
+
+### Stale Tasks (open with no recent activity - estimate from bd list output)
+- **{title}** (`task-id`) - {status/priority info}
+...
+
+### Potential Duplicates
+- **{title A}** (`id`) ~ **{title B}** (`id`) - similar scope
+...
+
+### Missing Labels/Priority
+- **{title}** (`id`) - no labels, priority P4
+...
+
+### Done but Not Closed
+- **{title}** (`id`) - status done
+...
+```
+
+If no issues found in a category, skip it.
+If backlog is clean, say so and suggest Review backlog or Explore idea instead.
+
+### Step C3: Interactive Triage
+
+For each group, walk through items and ask:
+
+```
+AskUserQuestion(
+  questions=[{
+    question: "{task title} ({task-id}). What to do?",
+    header: "Triage",
+    options: [
+      { label: "Close", description: "No longer needed" },
+      { label: "Keep", description: "Still relevant, skip" },
+      { label: "Reprioritize", description: "Change priority" }
+    ],
+    multiSelect: false
+  }]
+)
+```
+
+For closing:
+- `bd close <id>`
+- If closing as duplicate: `bd comments add <other-id> "Absorbed from {closed-id}: {title}"` then `bd close <id>`
+
+All mutations require user approval.
+Continue until all groups processed or user says "enough".
+
+### Step C4: Summary & Exit
+
+```
+## Cleanup Summary
+
+- Closed: {N} tasks
+- Reprioritized: {M} tasks
+- Skipped: {K} tasks
+```
+
+If active task:
+
+```bash
+bd comments add <task-id> "Cleanup: closed {N}, reprioritized {M}"
 ```
 
 ---
 
-## Explore Mode
+## Output
 
-Interactive exploration of an idea or concept. Ask probing questions, share insights, challenge assumptions. Build shared understanding before jumping to implementation.
-
-**This is a conversation, not a checklist.** One question or insight at a time.
-
-### Step E1: Capture Topic
-
-If argument provided: use it as topic.
-If not: ask "What idea or concept do you want to explore?"
-
-### Step E2: Open with Insights
-
-Start with 1-2 observations or connections, then ask the first probing question:
+### After Review Backlog / Explore Idea modes:
 
 ```
-## Let's explore: {topic}
-
-**Insight:** {initial observation - what's interesting, non-obvious, or connected to something in the project}
-
-**Question:** {probing question that helps define scope or challenges an assumption}
+┌─ LETS ──────────────────────────────────┐
+│  Plan a task?  /lets:plan               │
+│  Start work?   /lets:start              │
+└─────────────────────────────────────────┘
 ```
 
-### Step E3: Conversation Loop
-
-After each user response:
-
-1. **Acknowledge** - brief, no fluff ("Good point." / "That changes things.")
-2. **Build** - add an insight or connection based on their answer
-3. **Probe** - ask the next question that goes deeper or shifts angle
-
-### Question Types
-
-- **Assumption challenges:** "You're assuming X - what if Y instead?"
-- **Edge case probes:** "What happens when Z?"
-- **Trade-off surfacing:** "This gives you A but costs B - is that worth it?"
-- **Scope questions:** "Do you actually need X, or is Y enough for now?"
-- **User perspective:** "From the end user's view, what changes?"
-- **Feasibility:** "What's the simplest version of this that still delivers value?"
-- **Connections:** "This reminds me of {existing thing} - could we reuse/extend it?"
-
-### What Makes Good Insights
-
-- Connect dots between the idea and existing project patterns
-- Surface things that "almost exist" already
-- Flag decisions that are easy to change now but expensive later
-- Show non-obvious implications of a choice
-- Note when two goals conflict
-
-### Step E4: Exit & Capture
-
-Signals to wrap up:
-- User gives short answers (topic exhausted)
-- Key questions covered
-- User explicitly says "enough" / "let's move on"
-
-When wrapping up, summarize key findings:
+### After Quick Brainstorm:
 
 ```
-## Exploration Summary
-
-**Topic:** {what we explored}
-
-**Key insights:**
-- {insight 1}
-- {insight 2}
-
-**Decisions made:**
-- {decision 1}
-
-**Open questions:**
-- {anything unresolved}
+┌─ LETS ──────────────────────────────────┐
+│  Go deeper?  /lets:brainstorm           │
+│  Plan?       /lets:plan                 │
+│  Start?      /lets:start               │
+└─────────────────────────────────────────┘
 ```
 
-If active task exists, record to beads:
-
-```bash
-bd comments add <task-id> "Exploration: {topic}
-- {key insight 1}
-- {key insight 2}"
-```
-
-### Rules (Explore Mode)
-
-- **No agents** - direct conversation
-- **No code changes** - exploration produces understanding, not code
-- Respond in user's language
-
-### Output (Explore Mode)
+### After Cleanup:
 
 ```
 ┌─ LETS ─────────────────────────┐
-│  Plan?   /lets:plan            │
-│  Start?  /lets:start           │
+│  Brainstorm?  /lets:brainstorm │
+│  Start?       /lets:start      │
 └────────────────────────────────┘
 ```
 
-If exploration produced a clear task idea, ask: "Want me to create a task for this?" (plain text, not in LETS box).
+## Rules
+
+- All task mutations (create, close, update) require user approval
+- No agents in Quick brainstorm and Cleanup modes
+- Explorer + agents only in Review backlog and Explore idea modes
+- All agents launched in a SINGLE message (parallel)
+- If explorer fails or returns thin profile (<5 tasks), degrade to Quick mode
+- Explorer profile max ~500 words (passed to multiple agents)
+- Respond in user's language

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -39,7 +39,7 @@ cat "$ROOT/.lets/plans/${SLUG}.md" 2>/dev/null
 # Fallback: try without feature/ prefix (worktrees)
 cat "$ROOT/.lets/plans/${BRANCH}.md" 2>/dev/null
 
-# Fallback: glob match by task-id
+# Fallback: match by task-id
 ls "$ROOT/.lets/plans/"*${TASK_ID}* 2>/dev/null
 ```
 

--- a/commands/install.md
+++ b/commands/install.md
@@ -69,7 +69,7 @@ Team:     /lets:plan -> /lets:team run -> monitor -> /lets:review --local -> /le
 | `/lets:team` | Utility | Parallel implementation with Agent Teams |
 | `/lets:status` | Utility | Task overview anytime |
 | `/lets:note` | Utility | Add note to active task |
-| `/lets:brainstorm` | Planning | Interactive backlog helper - review, prioritize, spot patterns, create tasks |
+| `/lets:brainstorm` | Planning | Interactive ideation - review backlog, explore ideas, quick brainstorm, cleanup |
 
 ### Planning Skills (for bigger tasks)
 
@@ -81,7 +81,7 @@ Team:     /lets:plan -> /lets:team run -> monitor -> /lets:review --local -> /le
 **Rule of thumb:** Can you write a 1-sentence requirement?
 - YES, small task -> work directly
 - YES, medium/large -> `/lets:plan` then `/lets:execute`
-- NO -> `/lets:brainstorm` to clarify, then `/lets:plan`
+- NO -> `/lets:brainstorm` to explore and clarify, then `/lets:plan`
 
 ### Key Rules
 

--- a/commands/worktree.md
+++ b/commands/worktree.md
@@ -152,15 +152,17 @@ LETS: {symlinked / not available}
 
 ## Next Steps
 
-Open a new terminal and run:
+You can continue working right here - Claude Code automatically switches to the worktree directory.
+Use `/lets:start` to pick a task and begin.
+
+Or open a **new terminal** for parallel work:
 
 ```bash
 cd {absolute-worktree-path} && claude
 ```
 
-Then use `/lets:start` to pick a task and begin working.
-
 ┌─ LETS ─────────────────────────┐
+│  Start?   /lets:start          │
 │  List?    /lets:worktree list  │
 │  Info?    /lets:worktree info  │
 └────────────────────────────────┘

--- a/hooks/rules-context.md
+++ b/hooks/rules-context.md
@@ -130,6 +130,7 @@ GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 - `.beads/redirect` points to main repo's `.beads/` - same task database
 - Session refs are per-branch: `.session-start-ref-worktree-<name>` (parallel sessions don't collide)
 - `project-root` is the worktree path (not main repo)
+- **Glob tool does NOT follow symlinks.** Always use Bash (`ls`, `cat`) to find/read files in `.lets/` and `.beads/` - never use Glob for symlinked paths
 
 **What NOT to do in a worktree:**
 - Don't create additional `feature/` branches - `worktree-<name>` IS the working branch

--- a/hooks/rules-context.md
+++ b/hooks/rules-context.md
@@ -59,7 +59,7 @@ Don't wait for `/lets:note` - write insights as they happen. If no active task, 
 
 ## Agent Rules
 
-- When launching expert agents for `/lets:review`, `/lets:pr`, `/lets:opinion`, `/lets:ask`, `/lets:plan` - use ONLY `lets:*` agents (`lets:architect`, `lets:security`, etc.)
+- When launching expert agents for `/lets:review`, `/lets:pr`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:brainstorm` - use ONLY `lets:*` agents (`lets:architect`, `lets:security`, etc.)
 - Never use `general-purpose` or other non-lets subagent types for expert work
 
 ### Directed Search vs Exploration
@@ -285,7 +285,7 @@ This applies when: presenting implementation approaches, choosing between soluti
 | `/lets:pr` | Code | PR review lifecycle (review, respond, follow-up, approve) |
 | `/lets:opinion` | Expert | Technical decision (3-5 agents) |
 | `/lets:ask` | Expert | Quick expert consultation (1 agent) |
-| `/lets:brainstorm` | Planning | Interactive backlog helper - review, prioritize, spot patterns, create tasks |
+| `/lets:brainstorm` | Planning | Interactive ideation - review backlog, explore ideas, quick brainstorm, cleanup |
 | `/lets:plan` | Planning | Structured planning with agents - architecture + implementation plan |
 | `/lets:execute` | Planning | Execute plan from /lets:plan via native plan mode |
 | `/lets:status` | Utility | Task overview and project status |


### PR DESCRIPTION
## Summary

Redesign brainstorm from 2 modes to 4 modes with explorer pre-pass and parallel agent dispatch.

**4 modes:**
- **Review backlog** (heavy) - explorer + 3-5 agents analyze project state, generate ideas
- **Explore idea** (heavy) - explorer + agents research a topic from different angles
- **Quick brainstorm** (light) - fast context scan, direct conversation, no agents
- **Cleanup** - triage stale tasks, duplicates, orphans, unassigned tasks

**Key design:**
- Heavy Mode Flow shared template - Review and Explore set mode variables, share pipeline
- Explorer gathers context profile, command selects agents from profile signals
- Fallback: heavy → quick if explorer fails or thin profile (<5 tasks)
- Signal-based agent selection (9 eligible agents, cap at 5)

## Changes
- `ff0c004` feat: Add orphan and unassigned task triage to Cleanup mode
- `0a25136` fix: Address review findings in brainstorm redesign
- `68453be` feat: Redesign brainstorm with explorer, agents, and 4 modes
- `ecec2d0` fix: Add worktree symlink rule - Glob tool doesn't follow symlinks
- `eafb5de` docs: Update worktree next steps

## Task
lets-7nr3v: Redesign /lets:brainstorm - proactive idea generation with parallel agents

## Test plan
- [ ] Test Review backlog mode (heavy) - full agent flow
- [ ] Test Explore idea mode (heavy) - topic-focused agents
- [ ] Test Quick brainstorm mode (light) - no agents
- [ ] Test Cleanup mode - triage stale tasks
- [ ] Test fallback degradation (heavy → quick)
- [ ] Verify agent selection logic

---
Generated with LETS plugin