### PR TITLE
feat: Add marketplace distribution support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "name": "lets-workflow",
+  "description": "Development workflow plugin for Claude Code with session management, expert code review, and task tracking",
+  "owner": {
+    "name": "umbo",
+    "url": "https://github.com/nickolay-umbo"
+  },
+  "plugins": [
+    {
+      "name": "lets",
+      "source": "./",
+      "description": "Development workflow with session management, code review, and task tracking",
+      "version": "0.3.1"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,11 +1,13 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.2.2",
+  "version": "0.3.1",
   "author": {
-    "name": "umbo"
+    "name": "umbo",
+    "url": "https://github.com/nickolay-umbo"
   },
   "license": "MIT",
-  "repository": "https://github.com/nickolay-umbo/lets-plugin-claude",
+  "homepage": "https://github.com/restarter/lets-workflow",
+  "repository": "https://github.com/restarter/lets-workflow",
   "keywords": ["workflow", "review", "sessions", "beads", "code-review", "task-tracking"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-03-08
+
+Marketplace release - plugin available via Claude Code marketplace.
+
+### Added
+- `.claude-plugin/marketplace.json` for marketplace distribution
+- `LICENSE` file (MIT)
+- Marketplace and local install paths in README
+
+### Changed
+- `plugin.json`: added homepage, fixed repository URL to `restarter/lets-workflow`, bumped version
+- `CLAUDE.md`: fixed header from old repo name
+- README Quick Start rewritten with marketplace install instructions
+- README version badge now dynamic (from GitHub tags)
+- `scripts/release.sh`: syncs marketplace.json version on release
+
 ## [0.3.0] - 2026-03-07
 
 README rewrite, install/init split, and interactive planning.
@@ -166,6 +182,9 @@ Initial release with expert agents team.
 - SessionStart hook injecting workflow rules
 - Plugin structure: commands, agents, hooks
 
+[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/restarter/lets-workflow/compare/v0.3.0...v0.3.1
+[0.3.0]: https://github.com/restarter/lets-workflow/compare/v0.2.4...v0.3.0
 [0.2.4]: https://github.com/restarter/lets-workflow/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/restarter/lets-workflow/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/restarter/lets-workflow/compare/v0.2.1...v0.2.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# lets-plugin-claude
+# lets-workflow
 
 Claude Code plugin for development workflow with session management, code review, and task tracking.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 umbo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 *Stop babysitting your AI. Start shipping with it.*
 
 [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-blueviolet)](https://claude.com/claude-code)
-[![Version](https://img.shields.io/badge/version-0.3.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/github/v/tag/restarter/lets-workflow?label=version&color=blue)](CHANGELOG.md)
 
 </div>
 
@@ -41,14 +41,35 @@ You get a team of 13 expert agents and a structured workflow - but you stay in c
 
 ## 🚀 Quick Start
 
-```bash
-# 1. Add plugin to Claude Code
-git clone https://github.com/restarter/lets-workflow ~/.claude/plugins/lets
+### Install
 
-# 2. First-time global setup (installs beads plugin, verifies environment)
+**Option A: From marketplace (recommended)**
+
+In Claude Code:
+```
+/plugin marketplace add restarter/lets-workflow
+/plugin install lets
+```
+
+**Option B: From local clone**
+
+```bash
+git clone https://github.com/restarter/lets-workflow
+```
+
+Then in Claude Code:
+```
+/plugin marketplace add ./lets-workflow
+/plugin install lets
+```
+
+### Setup
+
+```bash
+# First-time global setup (installs beads plugin, verifies environment)
 /lets:install
 
-# 3. Initialize current project (creates .lets/ structure, config, statusline)
+# Initialize current project (creates .lets/ structure, config, statusline)
 /lets:init
 ```
 
@@ -266,6 +287,8 @@ All generated files go to `.lets/` (gitignored):
 ```
 
 Interactive worktrees are stored in `.worktrees/` (gitignored).
+
+> **Note:** LETS requires the [beads](https://github.com/steveyegge/beads) plugin for task tracking. `/lets:install` will guide you through installing it.
 
 ## 📦 Dependencies
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -47,7 +47,7 @@ if [ -z "$SESSIONS" ]; then
 fi
 ```
 
-Read and present a compact summary of recent sessions (last 1-3). Focus on: what was done, key decisions, next steps suggested.
+**Read EACH session file** found above using the Read tool (up to 3 files in parallel). Then present a compact summary of all sessions. Focus on: what was done, key decisions, next steps suggested.
 
 ## Step 2: Git State
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,6 +62,12 @@ if ! grep -q "\[$NEW_VERSION\]" CHANGELOG.md 2>/dev/null; then
     exit 1
 fi
 
+# Verify repo URLs are consistent
+if grep -q 'lets-plugin-claude' .claude-plugin/plugin.json; then
+    echo -e "${RED}Error: plugin.json still references old repo name 'lets-plugin-claude'${NC}"
+    exit 1
+fi
+
 # Update plugin.json
 echo "  Updating .claude-plugin/plugin.json"
 python3 -c "
@@ -74,9 +80,23 @@ with open('.claude-plugin/plugin.json', 'w') as f:
     f.write('\n')
 "
 
+# Update marketplace.json
+echo "  Updating .claude-plugin/marketplace.json"
+python3 -c "
+import json
+with open('.claude-plugin/marketplace.json', 'r') as f:
+    data = json.load(f)
+for p in data['plugins']:
+    if p['name'] == 'lets':
+        p['version'] = '$NEW_VERSION'
+with open('.claude-plugin/marketplace.json', 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+"
+
 # Commit, tag, push
 echo "  Committing..."
-git add .claude-plugin/plugin.json
+git add .claude-plugin/plugin.json .claude-plugin/marketplace.json
 git commit -m "chore: Bump version to $NEW_VERSION"
 
 echo "  Tagging v$NEW_VERSION..."


### PR DESCRIPTION
## Summary

Add marketplace distribution support so the plugin can be installed via Claude Code marketplace.

- Create `marketplace.json` for marketplace catalog (flat structure, `source: ./`)
- Update `plugin.json` with homepage, correct repo URL, version 0.3.1
- Add MIT `LICENSE` file
- Rewrite README Quick Start with marketplace-first install instructions
- Fix `CLAUDE.md` header from old repo name (`lets-plugin-claude` -> `lets-workflow`)
- Add CHANGELOG 0.3.1 entry with complete compare links
- Update `release.sh` with marketplace.json version sync and URL validation

## Install (after merge)

**Marketplace:**
```
/plugin marketplace add restarter/lets-workflow
/plugin install lets
```

**Local:**
```
git clone https://github.com/restarter/lets-workflow
/plugin marketplace add ./lets-workflow
/plugin install lets
```

## Task

lets-i5ayk: Prepare plugin for marketplace release (epic - stays open for testing/publishing)

---
Generated with LETS plugin