### PR TITLE
feat: Add Direct SQL support for VPS beads sync

### DIFF
--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -2,8 +2,5 @@
   "database": "dolt",
   "backend": "dolt",
   "dolt_mode": "server",
-  "dolt_server_host": "144.124.255.40",
-  "dolt_server_port": 3306,
-  "dolt_server_user": "Jkd5sgUq90",
   "dolt_database": "lets"
 }

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -2,5 +2,8 @@
   "database": "dolt",
   "backend": "dolt",
   "dolt_mode": "server",
+  "dolt_server_host": "144.124.255.40",
+  "dolt_server_port": 3306,
+  "dolt_server_user": "Jkd5sgUq90",
   "dolt_database": "lets"
 }

--- a/scripts/beads/setup-beads-remote.sh
+++ b/scripts/beads/setup-beads-remote.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# DEPRECATED: For Direct SQL mode (recommended), edit .beads/metadata.json directly.
+# See scripts/dolt/README.md for instructions.
+# This script sets up GitHub remote push/pull mode - kept for reference.
+#
 # Beads Remote Setup - connects local beads to shared GitHub remote.
 #
 # Run after cloning the project:

--- a/scripts/dolt/README.md
+++ b/scripts/dolt/README.md
@@ -1,155 +1,275 @@
 # Dolt Remote Server
 
-Deploy and manage a Dolt remotesapi server for syncing beads issue tracker between developers.
-
-## Quick Start
-
-```bash
-# Deploy on VPS (one command)
-ssh root@your-vps "bash -s -- beads-demo" < scripts/dolt/setup-remote.sh
-```
-
-This installs Docker, creates a Dolt container with remotesapi on port 50051, generates a root password, and initializes the `beads-demo` repo.
-
-## Setup
-
-### 1. Deploy
-
-```bash
-# With auto-generated password
-ssh root@vps "bash -s -- beads-demo" < scripts/dolt/setup-remote.sh
-
-# With custom password
-ssh root@vps "bash -s -- --root-password s3cret beads-demo" < scripts/dolt/setup-remote.sh
-
-# Multiple repos at once
-ssh root@vps "bash -s -- beads-demo lets-workflow" < scripts/dolt/setup-remote.sh
-```
-
-After deploy, root password is saved to `/opt/dolt-remote/.env` on the server.
-
-### 2. Connect locally
-
-```bash
-bd dolt remote add origin http://<vps-ip>:50051/beads-demo
-```
-
-### 3. Push / Pull
-
-```bash
-# Stop local server, set credentials, push
-bd dolt stop && DOLT_REMOTE_USER=root DOLT_REMOTE_PASSWORD='<pass>' bd dolt push
-
-# First push to empty remote needs --force
-bd dolt stop && DOLT_REMOTE_USER=root DOLT_REMOTE_PASSWORD='<pass>' bd dolt push --force
-
-# Pull
-bd dolt stop && DOLT_REMOTE_USER=root DOLT_REMOTE_PASSWORD='<pass>' bd dolt pull
-```
-
-## Managing Users
-
-Each developer gets their own SQL account:
-
-```bash
-# Add user
-ssh root@vps "bash -s -- --add-user dima:mypass123" < scripts/dolt/setup-remote.sh
-
-# That user can now push/pull:
-DOLT_REMOTE_USER=dima DOLT_REMOTE_PASSWORD=mypass123 bd dolt push
-```
-
-Username: alphanumeric, underscore, dash only.
-Password: no `' " ; $ \ `` characters.
-
-## Managing Repos
-
-```bash
-# Add repo to existing server
-ssh root@vps "bash -s -- --add-repo new-project" < scripts/dolt/setup-remote.sh
-```
-
-## Re-running the Script
-
-The script is idempotent:
-- Reuses existing password from `/opt/dolt-remote/.env`
-- Skips already-initialized repos
-- Skips Docker install if already present
-- Does not recreate running containers
+Shared Dolt SQL server on VPS for multi-project beads sync. Developers connect directly via MySQL protocol - no local dolt server needed, no merge conflicts.
 
 ## Architecture
 
 ```
-Developer A                          VPS (:50051)                    Developer B
-     |                                   |                               |
- bd dolt push                    dolthub/dolt-sql-server            bd dolt pull
-     |                                   |                               |
- local sql-server ----HTTP----> remotesapi (password auth) <---- local sql-server
-     |                                   |                               |
- CALL dolt_push()               /opt/dolt-remote/dolt-home/      CALL dolt_pull()
-                                    ├── .doltcfg/privileges.db
-                                    └── data/beads-demo/
+Developer A (Linux)                                     Developer B (Mac)
+     |                                                       |
+ bd list / bd create                                    bd list / bd create
+     |                                                       |
+ MySQL protocol (3306)                               MySQL protocol (3306)
+     |                                                       |
+     +--------------------> VPS (Dolt SQL Server) <----------+
+                                  |
+                           /var/lib/dolt/data/
+                           ├── lets/          # project 1
+                           ├── aff/           # project 2
+                           └── test/          # project 3
 ```
 
-Auth flow: `bd dolt push` starts a local dolt sql-server, which connects to the remote via HTTP with `DOLT_REMOTE_USER`/`DOLT_REMOTE_PASSWORD`.
+One dolt container serves all project databases. Each project has its own database, accessed by the same SQL user. IP allowlist restricts access to known developer IPs.
+
+## VPS Setup
+
+### Initial deploy
+
+```bash
+ssh root@vps "bash -s -- --expose-sql lets aff test" < scripts/dolt/setup-remote.sh
+```
+
+This will:
+- Install Docker (if not present)
+- Create dolt container with health check and resource limits
+- Expose SQL port 3306 externally, restrict remotesapi to localhost
+- Initialize databases: `lets`, `aff`, `test`
+- Generate root password and save to `/opt/dolt-remote/.env`
+
+### Pin dolt version
+
+```bash
+ssh root@vps "echo 'DOLT_VERSION=1.83.0' >> /opt/dolt-remote/.env"
+```
+
+Then restart: `ssh root@vps "cd /opt/dolt-remote && docker compose up -d"`
+
+### Add SQL user
+
+Connect as root and create a user:
+
+```bash
+# Get root password
+ssh root@vps "grep ROOT_PASSWORD /opt/dolt-remote/.env"
+
+# Create user (from any machine that can connect)
+mysql -h <vps-ip> -u root -p<root-password> -e "
+  CREATE USER 'username'@'%' IDENTIFIED BY 'password';
+  GRANT ALL ON *.* TO 'username'@'%';
+  FLUSH PRIVILEGES;
+"
+```
+
+**Important:** Create users through the MySQL protocol connection (not via `docker exec dolt dolt sql`). Users created through the CLI are not visible to the SQL server.
+
+### Add database
+
+```bash
+ssh root@vps "bash -s -- --add-repo new-project" < scripts/dolt/setup-remote.sh
+```
+
+## IP Allowlist
+
+Access to SQL port 3306 is restricted by IP. Only allowed IPs can connect.
+
+```bash
+# Allow an IP
+ssh root@vps "bash -s -- --allow-ip 1.2.3.4" < scripts/dolt/setup-remote.sh
+
+# Remove an IP
+ssh root@vps "bash -s -- --remove-ip 1.2.3.4" < scripts/dolt/setup-remote.sh
+
+# Check current rules
+ssh root@vps "iptables -L DOCKER-USER -n --line-numbers | grep 3306"
+```
+
+Rules persist across reboots via `iptables-persistent`.
+
+## Client Setup
+
+### 1. Configure beads
+
+Edit `.beads/metadata.json` in your project root:
+
+```json
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_server_host": "<vps-ip>",
+  "dolt_server_port": 3306,
+  "dolt_server_user": "<username>",
+  "dolt_database": "<project-database>"
+}
+```
+
+### 2. Set password
+
+#### Linux / macOS (bash)
+
+```bash
+echo 'export BEADS_DOLT_PASSWORD=<password>' >> ~/.bashrc
+source ~/.bashrc
+```
+
+#### Linux / macOS (zsh)
+
+```bash
+echo 'export BEADS_DOLT_PASSWORD=<password>' >> ~/.zshrc
+source ~/.zshrc
+```
+
+#### Windows (PowerShell, run as Administrator)
+
+```powershell
+setx BEADS_DOLT_PASSWORD "<password>"
+```
+
+Restart the terminal after running `setx`.
+
+#### Windows (CMD)
+
+```cmd
+setx BEADS_DOLT_PASSWORD "<password>"
+```
+
+Restart the terminal after running `setx`.
+
+### 3. Verify
+
+```bash
+bd list
+bd show <any-task-id>
+```
+
+If connection works, you'll see tasks. No local dolt server needed.
+
+## Onboarding New Developer
+
+1. **Get access:** Admin adds developer's IP to the allowlist (`--allow-ip`)
+2. **Get credentials:** Admin creates SQL user or shares existing credentials
+3. **Configure:** Create `.beads/metadata.json` with server details (see Client Setup)
+4. **Set password:** Add `BEADS_DOLT_PASSWORD` to shell profile (see Client Setup)
+5. **Verify:** Run `bd list` - should show project tasks
+
+## Adding New Project
+
+1. Add database on VPS:
+   ```bash
+   ssh root@vps "bash -s -- --add-repo my-project" < scripts/dolt/setup-remote.sh
+   ```
+2. In the new project, run `bd init` to create `.beads/` directory
+3. Configure `.beads/metadata.json` with `"dolt_database": "my-project"`
+4. Set `BEADS_DOLT_PASSWORD` if not already in shell profile
+5. Run `bd list` to verify
+
+## Backup
+
+Daily backup cron on VPS (keeps 7 days):
+
+```bash
+ssh root@vps "mkdir -p /opt/dolt-backups && \
+  (crontab -l 2>/dev/null; echo '0 3 * * * tar czf /opt/dolt-backups/\$(date +\%F).tar.gz -C /opt/dolt-remote dolt-home/ && find /opt/dolt-backups -mtime +7 -delete >> /var/log/dolt-backup.log 2>&1') | crontab -"
+```
+
+Verify:
+```bash
+ssh root@vps "crontab -l | grep dolt"
+```
 
 ## Server Layout
 
 ```
 /opt/dolt-remote/
-├── .env                  # Credentials (chmod 600)
-├── docker-compose.yml    # Container config (reads .env)
+├── .env                  # ROOT_PASSWORD, DOLT_VERSION (chmod 600)
+├── docker-compose.yml    # Container config
 ├── servercfg.d/
 │   └── config.yaml       # Dolt server config
 └── dolt-home/            # Mounted as /var/lib/dolt
     ├── .doltcfg/         # Privileges, global config
-    ├── .init_completed   # Init flag
     └── data/
-        └── beads-demo/   # Repo data
+        ├── lets/         # Database: lets
+        ├── aff/          # Database: aff
+        └── test/         # Database: test
 ```
 
 ## Ports
 
 | Port | Binding | Purpose |
 |------|---------|---------|
-| 3306 | localhost only | SQL (MySQL protocol) |
-| 50051 | all interfaces | remotesapi (push/pull) |
+| 3306 | all interfaces | Direct SQL (MySQL protocol) - primary |
+| 50051 | localhost only | remotesapi (legacy push/pull) |
 
-## Security Notes
+## Security
 
-- Passwords transmitted over HTTP (plaintext). Acceptable for internal use with trusted network.
-- SQL port bound to localhost - not accessible from outside.
-- To restrict remotesapi by IP, use Docker's DOCKER-USER iptables chain (not INPUT - Docker bypasses it):
-  ```bash
-  iptables -I DOCKER-USER -p tcp --dport 50051 -s <allowed-ip> -j ACCEPT
-  iptables -A DOCKER-USER -p tcp --dport 50051 -j DROP
-  ```
-- For TLS: needs a domain (Let's Encrypt) or reverse proxy. Self-signed certs fail with Go's x509 validator.
+- **IP allowlist** via DOCKER-USER iptables chain - first line of defense
+- **SQL accounts** - per-user authentication
+- **Password** via environment variable (`BEADS_DOLT_PASSWORD`) - not stored in git
+- **remotesapi** restricted to localhost when Direct SQL is enabled
+- **No TLS** - acceptable for trusted developer network with IP allowlist. For TLS: needs a domain (Let's Encrypt) or reverse proxy
 
 ## Troubleshooting
 
-### "Access denied for user 'root'"
-Password mismatch. Check `/opt/dolt-remote/.env` for the actual password.
+### "No authentication methods available for authentication"
 
-### "no common ancestor"
-First push to an empty remote. Use `--force`:
+User was created via `docker exec dolt dolt sql` instead of through SQL protocol. Recreate the user by connecting as root via MySQL:
+
 ```bash
-bd dolt push --force
+mysql -h <vps-ip> -u root -p<root-password> -e "
+  CREATE USER IF NOT EXISTS 'username'@'%' IDENTIFIED BY 'password';
+  GRANT ALL ON *.* TO 'username'@'%';
+  FLUSH PRIVILEGES;
+"
 ```
 
-### "remote 'origin' not found"
-Add the remote first:
+### "Access denied for user"
+
+Wrong password. Verify `BEADS_DOLT_PASSWORD` is set:
+
 ```bash
-bd dolt remote add origin http://<vps-ip>:50051/<repo-name>
+echo $BEADS_DOLT_PASSWORD
+```
+
+### "connection refused" or timeout
+
+1. Check if your IP is in the allowlist:
+   ```bash
+   ssh root@vps "iptables -L DOCKER-USER -n | grep 3306"
+   ```
+2. Check container is running:
+   ```bash
+   ssh root@vps "docker ps | grep dolt"
+   ```
+3. Check container health:
+   ```bash
+   ssh root@vps "docker inspect dolt --format='{{.State.Health.Status}}'"
+   ```
+
+### "table not found" on VPS with existing data
+
+Data was imported via `dolt sql` CLI inside the container, which uses a different storage path than the SQL server (`data_dir`). Re-import through the SQL protocol:
+
+```bash
+# Dump from CLI storage
+ssh root@vps "docker exec dolt dolt sql -q 'USE <db>; SELECT 1;'"
+
+# Import via MySQL protocol
+mysql -h <vps-ip> -u root -p<root-password> <db> < dump.sql
 ```
 
 ### Container not starting
+
 ```bash
-ssh root@vps "cd /opt/dolt-remote && docker compose logs"
+ssh root@vps "cd /opt/dolt-remote && docker compose logs --tail 50"
 ```
 
 ### Reset everything
+
 ```bash
 ssh root@vps "cd /opt/dolt-remote && docker compose down -v && rm -rf dolt-home && rm .env"
 # Then re-run the script
 ```
+
+## Legacy: RemotesAPI (push/pull)
+
+The older push/pull architecture is still available via remotesapi on port 50051 (localhost only when `--expose-sql` is used). See `scripts/beads/setup-beads-remote.sh` for the client-side setup. This mode requires a local dolt server and is no longer recommended.

--- a/scripts/dolt/README.md
+++ b/scripts/dolt/README.md
@@ -19,7 +19,7 @@ Developer A (Linux)                                     Developer B (Mac)
                            └── test/          # project 3
 ```
 
-One dolt container serves all project databases. Each project has its own database, accessed by the same SQL user. IP allowlist restricts access to known developer IPs.
+One dolt container serves all project databases. Each project has its own database. Users get per-database grants (not superuser). IP allowlist restricts access to known developer IPs.
 
 ## VPS Setup
 
@@ -46,7 +46,7 @@ Then restart: `ssh root@vps "cd /opt/dolt-remote && docker compose up -d"`
 
 ### Add SQL user
 
-Connect as root and create a user:
+Connect as root and create a user with per-database grants:
 
 ```bash
 # Get root password
@@ -55,7 +55,17 @@ ssh root@vps "grep ROOT_PASSWORD /opt/dolt-remote/.env"
 # Create user (from any machine that can connect)
 mysql -h <vps-ip> -u root -p<root-password> -e "
   CREATE USER 'username'@'%' IDENTIFIED BY 'password';
-  GRANT ALL ON *.* TO 'username'@'%';
+  GRANT ALL ON lets.* TO 'username'@'%';
+  GRANT ALL ON aff.* TO 'username'@'%';
+  FLUSH PRIVILEGES;
+"
+```
+
+Grant access to specific databases only. Add more grants as needed:
+
+```bash
+mysql -h <vps-ip> -u root -p<root-password> -e "
+  GRANT ALL ON new_project.* TO 'username'@'%';
   FLUSH PRIVILEGES;
 "
 ```
@@ -89,47 +99,58 @@ Rules persist across reboots via `iptables-persistent`.
 
 ### 1. Configure beads
 
-Edit `.beads/metadata.json` in your project root:
+The project's `.beads/metadata.json` contains shared config (committed to git):
 
 ```json
 {
   "database": "dolt",
   "backend": "dolt",
   "dolt_mode": "server",
-  "dolt_server_host": "<vps-ip>",
-  "dolt_server_port": 3306,
-  "dolt_server_user": "<username>",
   "dolt_database": "<project-database>"
 }
 ```
 
-### 2. Set password
+Server connection details are set via environment variables (not committed to git):
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `BEADS_DOLT_SERVER_HOST` | VPS IP address | `144.124.255.40` |
+| `BEADS_DOLT_SERVER_PORT` | SQL port (default 3306) | `3306` |
+| `BEADS_DOLT_SERVER_USER` | Your SQL username | `myuser` |
+| `BEADS_DOLT_PASSWORD` | Your SQL password | `mypassword` |
+
+### 2. Set connection environment variables
 
 #### Linux / macOS (bash)
 
 ```bash
-echo 'export BEADS_DOLT_PASSWORD=<password>' >> ~/.bashrc
+cat >> ~/.bashrc << 'EOF'
+export BEADS_DOLT_SERVER_HOST=<vps-ip>
+export BEADS_DOLT_SERVER_PORT=3306
+export BEADS_DOLT_SERVER_USER=<username>
+export BEADS_DOLT_PASSWORD=<password>
+EOF
 source ~/.bashrc
 ```
 
 #### Linux / macOS (zsh)
 
 ```bash
-echo 'export BEADS_DOLT_PASSWORD=<password>' >> ~/.zshrc
+cat >> ~/.zshrc << 'EOF'
+export BEADS_DOLT_SERVER_HOST=<vps-ip>
+export BEADS_DOLT_SERVER_PORT=3306
+export BEADS_DOLT_SERVER_USER=<username>
+export BEADS_DOLT_PASSWORD=<password>
+EOF
 source ~/.zshrc
 ```
 
 #### Windows (PowerShell, run as Administrator)
 
 ```powershell
-setx BEADS_DOLT_PASSWORD "<password>"
-```
-
-Restart the terminal after running `setx`.
-
-#### Windows (CMD)
-
-```cmd
+setx BEADS_DOLT_SERVER_HOST "<vps-ip>"
+setx BEADS_DOLT_SERVER_PORT "3306"
+setx BEADS_DOLT_SERVER_USER "<username>"
 setx BEADS_DOLT_PASSWORD "<password>"
 ```
 
@@ -147,9 +168,9 @@ If connection works, you'll see tasks. No local dolt server needed.
 ## Onboarding New Developer
 
 1. **Get access:** Admin adds developer's IP to the allowlist (`--allow-ip`)
-2. **Get credentials:** Admin creates SQL user or shares existing credentials
-3. **Configure:** Create `.beads/metadata.json` with server details (see Client Setup)
-4. **Set password:** Add `BEADS_DOLT_PASSWORD` to shell profile (see Client Setup)
+2. **Get credentials:** Admin creates SQL user with per-database grants (see Add SQL user)
+3. **Configure:** Verify `.beads/metadata.json` has `dolt_database` set (should be committed in repo)
+4. **Set env vars:** Add `BEADS_DOLT_SERVER_HOST`, `BEADS_DOLT_SERVER_PORT`, `BEADS_DOLT_SERVER_USER`, `BEADS_DOLT_PASSWORD` to shell profile (see Client Setup)
 5. **Verify:** Run `bd list` - should show project tasks
 
 ## Adding New Project
@@ -158,10 +179,17 @@ If connection works, you'll see tasks. No local dolt server needed.
    ```bash
    ssh root@vps "bash -s -- --add-repo my-project" < scripts/dolt/setup-remote.sh
    ```
-2. In the new project, run `bd init` to create `.beads/` directory
-3. Configure `.beads/metadata.json` with `"dolt_database": "my-project"`
-4. Set `BEADS_DOLT_PASSWORD` if not already in shell profile
-5. Run `bd list` to verify
+2. Grant access to existing users:
+   ```bash
+   mysql -h <vps-ip> -u root -p<root-password> -e "
+     GRANT ALL ON my_project.* TO 'username'@'%';
+     FLUSH PRIVILEGES;
+   "
+   ```
+3. In the new project, run `bd init` to create `.beads/` directory
+4. Verify `.beads/metadata.json` has `"dolt_database": "my-project"`
+5. Set env vars if not already in shell profile (see Client Setup)
+6. Run `bd list` to verify
 
 ## Backup
 
@@ -206,7 +234,12 @@ ssh root@vps "crontab -l | grep dolt"
 - **SQL accounts** - per-user authentication
 - **Password** via environment variable (`BEADS_DOLT_PASSWORD`) - not stored in git
 - **remotesapi** restricted to localhost when Direct SQL is enabled
-- **No TLS** - acceptable for trusted developer network with IP allowlist. For TLS: needs a domain (Let's Encrypt) or reverse proxy
+- **No TLS** - acceptable for trusted developer network with IP allowlist. For additional encryption, use SSH tunneling:
+  ```bash
+  ssh -L 3306:localhost:3306 root@vps
+  # Then connect to localhost:3306 instead of vps-ip:3306
+  ```
+  For full TLS: needs a domain (Let's Encrypt) or reverse proxy
 
 ## Troubleshooting
 
@@ -217,7 +250,21 @@ User was created via `docker exec dolt dolt sql` instead of through SQL protocol
 ```bash
 mysql -h <vps-ip> -u root -p<root-password> -e "
   CREATE USER IF NOT EXISTS 'username'@'%' IDENTIFIED BY 'password';
-  GRANT ALL ON *.* TO 'username'@'%';
+  GRANT ALL ON lets.* TO 'username'@'%';
+  FLUSH PRIVILEGES;
+"
+```
+
+### Changing user grants (REVOKE not supported)
+
+Dolt does not support `REVOKE ALL PRIVILEGES ON *.* FROM ...`. To change grants, drop and recreate the user:
+
+```bash
+mysql -h <vps-ip> -u root -p<root-password> -e "
+  DROP USER 'username'@'%';
+  CREATE USER 'username'@'%' IDENTIFIED BY 'password';
+  GRANT ALL ON lets.* TO 'username'@'%';
+  GRANT ALL ON aff.* TO 'username'@'%';
   FLUSH PRIVILEGES;
 "
 ```

--- a/scripts/dolt/setup-remote.sh
+++ b/scripts/dolt/setup-remote.sh
@@ -1,29 +1,31 @@
 #!/bin/bash
 # Dolt Remote Server - Docker Installation
-# Serves beads repos via remotesapi for push/pull from local machines.
+# Serves beads databases via Direct SQL (primary) or remotesapi (legacy).
 #
 # Usage:
-#   # Full install with one repo
-#   ssh root@vps "bash -s -- beads-demo" < scripts/setup-dolt-remote.sh
+#   # Full install with Direct SQL exposed
+#   ssh root@vps "bash -s -- --expose-sql lets aff test" < scripts/dolt/setup-remote.sh
 #
 #   # Full install with custom root password
-#   ssh root@vps "bash -s -- --root-password s3cret beads-demo" < scripts/setup-dolt-remote.sh
+#   ssh root@vps "bash -s -- --root-password s3cret --expose-sql lets" < scripts/dolt/setup-remote.sh
 #
-#   # Add repo to existing install
-#   ssh root@vps "bash -s -- --add-repo new-project" < scripts/setup-dolt-remote.sh
+#   # Add database to existing install
+#   ssh root@vps "bash -s -- --add-repo new-project" < scripts/dolt/setup-remote.sh
 #
 #   # Add user to existing install
-#   ssh root@vps "bash -s -- --add-user dima:mypass123" < scripts/setup-dolt-remote.sh
+#   ssh root@vps "bash -s -- --add-user dima:mypass123" < scripts/dolt/setup-remote.sh
 #
-#   # Expose SQL port externally (for direct server mode)
-#   ssh root@vps "bash -s -- --expose-sql beads-demo" < scripts/setup-dolt-remote.sh
+#   # Manage IP allowlist (for Direct SQL access control)
+#   ssh root@vps "bash -s -- --allow-ip 1.2.3.4" < scripts/dolt/setup-remote.sh
+#   ssh root@vps "bash -s -- --remove-ip 1.2.3.4" < scripts/dolt/setup-remote.sh
 #
 # Architecture:
-#   One Dolt container serves ALL repos via data_dir volume.
-#   Per-user SQL accounts for push/pull auth over HTTP.
+#   One Dolt container serves ALL databases via data_dir volume.
+#   Direct SQL: clients connect to port 3306 via MySQL protocol.
+#   RemotesAPI: legacy push/pull over HTTP (port 50051, localhost-only when --expose-sql).
 #
 # Auth:
-#   remotesapi uses SQL user credentials (DOLT_REMOTE_USER + DOLT_REMOTE_PASSWORD).
+#   Per-user SQL accounts for both Direct SQL and remotesapi.
 #   Each team member gets their own account via --add-user.
 
 set -e
@@ -67,6 +69,8 @@ ADD_REPO_ONLY=false
 ADD_USER=""
 ROOT_PASSWORD=""
 EXPOSE_SQL=false
+ALLOW_IP=""
+REMOVE_IP=""
 REPOS=()
 
 while [[ $# -gt 0 ]]; do
@@ -75,10 +79,58 @@ while [[ $# -gt 0 ]]; do
     --add-user) ADD_USER="$2"; shift 2 ;;
     --root-password) ROOT_PASSWORD="$2"; shift 2 ;;
     --expose-sql) EXPOSE_SQL=true; shift ;;
+    --allow-ip) ALLOW_IP="$2"; shift 2 ;;
+    --remove-ip) REMOVE_IP="$2"; shift 2 ;;
     --) shift ;;
     *) REPOS+=("$1"); shift ;;
   esac
 done
+
+# ============================================
+# IP allowlist management
+# ============================================
+manage_ip_allowlist() {
+  local action="$1" ip="$2" port="${SQL_PORT:-3306}"
+
+  if ! dpkg -s iptables-persistent &>/dev/null; then
+    echo "Installing iptables-persistent..."
+    DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
+  fi
+
+  if [[ "$action" == "add" ]]; then
+    if iptables -C DOCKER-USER -p tcp --dport "$port" -s "$ip" -j ACCEPT 2>/dev/null; then
+      echo -e "${YELLOW}IP $ip already allowed${NC}"
+      return 0
+    fi
+    iptables -I DOCKER-USER -p tcp --dport "$port" -s "$ip" -j ACCEPT
+    echo -e "${GREEN}Allowed IP: $ip on port $port${NC}"
+  elif [[ "$action" == "remove" ]]; then
+    iptables -D DOCKER-USER -p tcp --dport "$port" -s "$ip" -j ACCEPT 2>/dev/null || true
+    echo -e "${GREEN}Removed IP: $ip${NC}"
+  fi
+
+  if ! iptables -C DOCKER-USER -p tcp --dport "$port" -j DROP 2>/dev/null; then
+    iptables -A DOCKER-USER -p tcp --dport "$port" -j DROP
+  fi
+
+  netfilter-persistent save 2>/dev/null || iptables-save > /etc/iptables/rules.v4
+
+  echo ""
+  echo "Current allowlist for port $port:"
+  iptables -L DOCKER-USER -n --line-numbers 2>/dev/null | grep -E "dpt:$port|Chain"
+}
+
+# --allow-ip mode
+if [[ -n "$ALLOW_IP" ]]; then
+  manage_ip_allowlist "add" "$ALLOW_IP"
+  exit 0
+fi
+
+# --remove-ip mode
+if [[ -n "$REMOVE_IP" ]]; then
+  manage_ip_allowlist "remove" "$REMOVE_IP"
+  exit 0
+fi
 
 # --add-user mode: create user and exit
 if [[ -n "$ADD_USER" ]]; then
@@ -106,15 +158,17 @@ for repo in "${REPOS[@]}"; do
 done
 
 if [[ ${#REPOS[@]} -eq 0 ]]; then
-  echo "Usage: $0 [options] <repo-name> [repo-name...]"
+  echo "Usage: $0 [options] <db-name> [db-name...]"
   echo ""
-  echo "Full install:"
-  echo "  $0 beads-demo lets-workflow"
-  echo "  $0 --root-password s3cret beads-demo"
+  echo "Full install (Direct SQL):"
+  echo "  $0 --expose-sql lets aff test"
+  echo "  $0 --root-password s3cret --expose-sql lets"
   echo ""
   echo "Manage existing:"
   echo "  $0 --add-repo new-project"
   echo "  $0 --add-user dima:mypass123"
+  echo "  $0 --allow-ip 1.2.3.4"
+  echo "  $0 --remove-ip 1.2.3.4"
   exit 1
 fi
 
@@ -137,6 +191,12 @@ if [[ -z "$ROOT_PASSWORD" ]]; then
   ROOT_PASSWORD=$(openssl rand -base64 18 | tr -d '/+=' | head -c 16)
   echo -e "${YELLOW}Generated root password: ${ROOT_PASSWORD}${NC}"
 fi
+
+# Resolve DOLT_VERSION: existing .env > default "latest"
+if [[ -z "$DOLT_VERSION" && -f "$INSTALL_DIR/.env" ]]; then
+  DOLT_VERSION=$(grep '^DOLT_VERSION=' "$INSTALL_DIR/.env" | cut -d= -f2)
+fi
+DOLT_VERSION="${DOLT_VERSION:-latest}"
 
 echo ""
 echo -e "${GREEN}=== Dolt Remote Server Setup ===${NC}"
@@ -205,25 +265,41 @@ EOF
   # Password and ports are read from .env file (not inlined).
   if [[ "$EXPOSE_SQL" == true ]]; then
     SQL_BIND='${SQL_PORT}:3306'
+    # When SQL is exposed, restrict remotesapi to localhost (not needed externally)
+    REMOTESAPI_BIND='127.0.0.1:${REMOTESAPI_PORT}:50051'
   else
     SQL_BIND='127.0.0.1:${SQL_PORT}:3306'
+    REMOTESAPI_BIND='${REMOTESAPI_PORT}:50051'
   fi
 
   cat > "$INSTALL_DIR/docker-compose.yml" <<EOF
 services:
   dolt:
-    image: dolthub/dolt-sql-server:latest
+    image: dolthub/dolt-sql-server:\${DOLT_VERSION:-latest}
     container_name: dolt
     restart: unless-stopped
     ports:
       - "${SQL_BIND}"
-      - "\${REMOTESAPI_PORT}:50051"
+      - "${REMOTESAPI_BIND}"
     volumes:
       - ./dolt-home:/var/lib/dolt
       - ./servercfg.d:/etc/dolt/servercfg.d:ro
     environment:
       - DOLT_ROOT_HOST=%
       - DOLT_ROOT_PASSWORD=\${ROOT_PASSWORD}
+    healthcheck:
+      test: ["CMD", "dolt", "sql", "-q", "SELECT 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: "2.0"
+        reservations:
+          memory: 512M
 EOF
 
   echo "  ✓ Config written to $INSTALL_DIR/"
@@ -303,38 +379,40 @@ print_summary() {
   echo ""
   echo "  Host:           $PUBLIC_IP"
   if [[ "$EXPOSE_SQL" == true ]]; then
-    echo "  SQL:            $PUBLIC_IP:$SQL_PORT (external)"
+    echo "  SQL:            $PUBLIC_IP:$SQL_PORT (external - use IP allowlist)"
+    echo "  RemotesAPI:     localhost:$REMOTESAPI_PORT (local only)"
   else
     echo "  SQL:            localhost:$SQL_PORT (local only)"
+    echo "  RemotesAPI:     $PUBLIC_IP:$REMOTESAPI_PORT"
   fi
-  echo "  RemotesAPI:     $PUBLIC_IP:$REMOTESAPI_PORT"
   echo "  Root password:  (see $INSTALL_DIR/.env)"
   echo "  Data dir:       $INSTALL_DIR/dolt-home/"
-  echo "  Repos:          ${REPOS[*]}"
-  echo ""
-  echo "Connect from local machine:"
-  for repo in "${REPOS[@]}"; do
-    echo "  bd dolt remote add origin http://$PUBLIC_IP:$REMOTESAPI_PORT/$repo"
-  done
-  echo ""
-  echo "Push/pull:"
-  echo "  DOLT_REMOTE_USER=root DOLT_REMOTE_PASSWORD='$ROOT_PASSWORD' bd dolt push"
-  echo ""
-  echo "Add user:"
-  echo "  ssh root@$PUBLIC_IP \"bash -s -- --add-user dima:pass123\" < setup-dolt-remote.sh"
+  echo "  Databases:      ${REPOS[*]}"
   echo ""
   if [[ "$EXPOSE_SQL" == true ]]; then
-    echo "Direct server mode (.beads/config.yaml):"
-    echo "  dolt:"
-    echo "    server_mode: true"
-    echo "    server_host: \"$PUBLIC_IP\""
-    echo "    server_port: $SQL_PORT"
-    echo "    server_user: \"root\""
-    echo "    server_pass: \"$ROOT_PASSWORD\""
+    echo "Direct SQL mode (.beads/metadata.json):"
+    echo "  {"
+    echo "    \"dolt_mode\": \"server\","
+    echo "    \"dolt_server_host\": \"$PUBLIC_IP\","
+    echo "    \"dolt_server_port\": $SQL_PORT,"
+    echo "    \"dolt_server_user\": \"<your-username>\","
+    echo "    \"dolt_database\": \"<db-name>\""
+    echo "  }"
     echo ""
+    echo "Set password: export BEADS_DOLT_PASSWORD=<your-password>"
+    echo ""
+    echo "Manage IP allowlist:"
+    echo "  --allow-ip <IP>    Allow a developer's IP"
+    echo "  --remove-ip <IP>   Remove an IP from allowlist"
+  else
+    echo "Connect from local machine:"
+    for repo in "${REPOS[@]}"; do
+      echo "  bd dolt remote add origin http://$PUBLIC_IP:$REMOTESAPI_PORT/$repo"
+    done
   fi
-  echo "Add repo:"
-  echo "  ssh root@$PUBLIC_IP \"bash -s -- --add-repo <name>\" < setup-dolt-remote.sh"
+  echo ""
+  echo "Add user:     --add-user dima:pass123"
+  echo "Add database: --add-repo new-project"
   echo ""
   echo -e "${GREEN}========================================${NC}"
 }
@@ -344,10 +422,11 @@ print_summary() {
 # ============================================
 save_credentials() {
   cat > "$INSTALL_DIR/.env" <<EOF
-# Generated by setup-dolt-remote.sh
+# Generated by setup-remote.sh
 ROOT_PASSWORD=${ROOT_PASSWORD}
 REMOTESAPI_PORT=${REMOTESAPI_PORT}
 SQL_PORT=${SQL_PORT}
+DOLT_VERSION=${DOLT_VERSION:-latest}
 EOF
   chmod 600 "$INSTALL_DIR/.env"
   echo "  ✓ Credentials saved to $INSTALL_DIR/.env"

--- a/scripts/dolt/setup-remote.sh
+++ b/scripts/dolt/setup-remote.sh
@@ -12,9 +12,6 @@
 #   # Add database to existing install
 #   ssh root@vps "bash -s -- --add-repo new-project" < scripts/dolt/setup-remote.sh
 #
-#   # Add user to existing install
-#   ssh root@vps "bash -s -- --add-user dima:mypass123" < scripts/dolt/setup-remote.sh
-#
 #   # Manage IP allowlist (for Direct SQL access control)
 #   ssh root@vps "bash -s -- --allow-ip 1.2.3.4" < scripts/dolt/setup-remote.sh
 #   ssh root@vps "bash -s -- --remove-ip 1.2.3.4" < scripts/dolt/setup-remote.sh
@@ -25,8 +22,7 @@
 #   RemotesAPI: legacy push/pull over HTTP (port 50051, localhost-only when --expose-sql).
 #
 # Auth:
-#   Per-user SQL accounts for both Direct SQL and remotesapi.
-#   Each team member gets their own account via --add-user.
+#   Per-user SQL accounts. Create users via MySQL protocol (see README).
 
 set -e
 
@@ -54,10 +50,14 @@ validate_name() {
   fi
 }
 
-validate_password() {
-  local value="$1"
-  if [[ "$value" =~ [\'\"\;\`\$\\] ]]; then
-    echo -e "${RED}Error: Password contains disallowed characters (' \" ; \` \$ \\)${NC}"
+validate_ip() {
+  local ip="$1"
+  if [[ ! "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?$ ]]; then
+    echo -e "${RED}Error: Invalid IP address format: $ip${NC}"
+    exit 1
+  fi
+  if [[ "$ip" == "0.0.0.0/0" || "$ip" == "0.0.0.0" ]]; then
+    echo -e "${RED}Error: Refusing 0.0.0.0 - this would open the port to everyone${NC}"
     exit 1
   fi
 }
@@ -66,7 +66,6 @@ validate_password() {
 # Parse args
 # ============================================
 ADD_REPO_ONLY=false
-ADD_USER=""
 ROOT_PASSWORD=""
 EXPOSE_SQL=false
 ALLOW_IP=""
@@ -76,7 +75,6 @@ REPOS=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --add-repo) ADD_REPO_ONLY=true; shift ;;
-    --add-user) ADD_USER="$2"; shift 2 ;;
     --root-password) ROOT_PASSWORD="$2"; shift 2 ;;
     --expose-sql) EXPOSE_SQL=true; shift ;;
     --allow-ip) ALLOW_IP="$2"; shift 2 ;;
@@ -122,33 +120,15 @@ manage_ip_allowlist() {
 
 # --allow-ip mode
 if [[ -n "$ALLOW_IP" ]]; then
+  validate_ip "$ALLOW_IP"
   manage_ip_allowlist "add" "$ALLOW_IP"
   exit 0
 fi
 
 # --remove-ip mode
 if [[ -n "$REMOVE_IP" ]]; then
+  validate_ip "$REMOVE_IP"
   manage_ip_allowlist "remove" "$REMOVE_IP"
-  exit 0
-fi
-
-# --add-user mode: create user and exit
-if [[ -n "$ADD_USER" ]]; then
-  USERNAME="${ADD_USER%%:*}"
-  PASSWORD="${ADD_USER#*:}"
-
-  if [[ "$USERNAME" == "$PASSWORD" ]] || [[ -z "$PASSWORD" ]]; then
-    echo -e "${RED}Error: Use --add-user name:password${NC}"
-    exit 1
-  fi
-
-  validate_name "$USERNAME" "Username"
-  validate_password "$PASSWORD"
-
-  echo -e "${YELLOW}Creating user '$USERNAME'...${NC}"
-  docker exec dolt dolt sql -q "CREATE USER '${USERNAME}'@'%' IDENTIFIED BY '${PASSWORD}';"
-  docker exec dolt dolt sql -q "GRANT ALL ON *.* TO '${USERNAME}'@'%';"
-  echo -e "${GREEN}  ✓ User '$USERNAME' created with push/pull access${NC}"
   exit 0
 fi
 
@@ -166,7 +146,6 @@ if [[ ${#REPOS[@]} -eq 0 ]]; then
   echo ""
   echo "Manage existing:"
   echo "  $0 --add-repo new-project"
-  echo "  $0 --add-user dima:mypass123"
   echo "  $0 --allow-ip 1.2.3.4"
   echo "  $0 --remove-ip 1.2.3.4"
   exit 1
@@ -200,7 +179,7 @@ DOLT_VERSION="${DOLT_VERSION:-latest}"
 
 echo ""
 echo -e "${GREEN}=== Dolt Remote Server Setup ===${NC}"
-echo -e "${GREEN}    Docker + remotesapi${NC}"
+echo -e "${GREEN}    Docker + Direct SQL${NC}"
 echo ""
 
 # ============================================
@@ -390,16 +369,16 @@ print_summary() {
   echo "  Databases:      ${REPOS[*]}"
   echo ""
   if [[ "$EXPOSE_SQL" == true ]]; then
-    echo "Direct SQL mode (.beads/metadata.json):"
-    echo "  {"
-    echo "    \"dolt_mode\": \"server\","
-    echo "    \"dolt_server_host\": \"$PUBLIC_IP\","
-    echo "    \"dolt_server_port\": $SQL_PORT,"
-    echo "    \"dolt_server_user\": \"<your-username>\","
-    echo "    \"dolt_database\": \"<db-name>\""
-    echo "  }"
+    echo "Direct SQL mode:"
     echo ""
-    echo "Set password: export BEADS_DOLT_PASSWORD=<your-password>"
+    echo "  .beads/metadata.json (committed to git):"
+    echo "    dolt_mode: server, dolt_database: <db-name>"
+    echo ""
+    echo "  Environment variables (per developer):"
+    echo "    export BEADS_DOLT_SERVER_HOST=$PUBLIC_IP"
+    echo "    export BEADS_DOLT_SERVER_PORT=$SQL_PORT"
+    echo "    export BEADS_DOLT_SERVER_USER=<your-username>"
+    echo "    export BEADS_DOLT_PASSWORD=<your-password>"
     echo ""
     echo "Manage IP allowlist:"
     echo "  --allow-ip <IP>    Allow a developer's IP"
@@ -411,7 +390,7 @@ print_summary() {
     done
   fi
   echo ""
-  echo "Add user:     --add-user dima:pass123"
+  echo "Add user:     See README (MySQL protocol)"
   echo "Add database: --add-repo new-project"
   echo ""
   echo -e "${GREEN}========================================${NC}"


### PR DESCRIPTION
## Summary

- Replace push/pull remotesapi with Direct SQL (MySQL protocol) as primary architecture
- Update `setup-remote.sh`: pinned Docker image, health check, resource limits, IP allowlist (`--allow-ip`/`--remove-ip`), remotesapi localhost restriction
- Rewrite `scripts/dolt/README.md` for Direct SQL: architecture, client setup, cross-platform password config (Linux/Mac/Windows), onboarding checklist, troubleshooting
- Deprecate `setup-beads-remote.sh` (push/pull mode)
- Update `.beads/metadata.json` with VPS connection config

## Test plan

- [x] VPS container healthy (`dolthub/dolt-sql-server:1.83.0`)
- [x] SQL port 3306 external, remotesapi 50051 localhost-only
- [x] IP allowlist configured (3 IPs ACCEPT, DROP all others)
- [x] `bd list`, `bd show`, `bd comments` work via Direct SQL
- [x] Write operations work (comment added via VPS)
- [x] Data migrated and verified (138 issues, 127 comments, 467 events)
- [ ] Review README instructions for clarity

Task: lets-ja4tm