### PR TITLE
docs: Update README, CLAUDE.md, CHANGELOG and agent colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## [Unreleased]
 
+### Added
+- Skill architecture (`skills/` directory) with two skill types: user-facing (auto-triggered) and internal (read by commands)
+- 4 skills: `commit`, `create-task`, `take-task` (user-facing), `detect-task` (internal)
+- Auto-triggered Skills table in `hooks/rules-context.md` and `commands/install.md`
+- beads-ui Docker web dashboard (`scripts/beads-ui/`) with deployment script
+- Branch return prompt after worktree creation
+
+### Changed
+- All 13 agent prompts upgraded to v2: tiered scoring ([BLOCKER]/[SUGGESTION]/[NIT]), self-contained behavioral modes, color assignments
+- `/lets:brainstorm` redesigned with 4 modes: review backlog, explore idea, quick brainstorm, cleanup
+- Commands thinned - shared logic extracted to skills (`commit.md` 208->11 lines, `start.md` -120 lines)
+- CLAUDE.md architecture decisions updated: agents define WHO+HOW, commands define WHAT+WHEN
+- Mandatory context tables removed from 5 commands (review, opinion, ask, plan, brainstorm) - now in agents
+
+### Fixed
+- beads-ui: input validation, firewall rules, deduplication (PR #35 review)
+
 ## [0.3.1] - 2026-03-08
 
 Marketplace release - plugin available via Claude Code marketplace.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,17 +7,18 @@ Claude Code plugin for development workflow with session management, code review
 ```
 .claude-plugin/plugin.json   # Plugin manifest
 commands/                     # Slash commands (/lets:start, /lets:done, /lets:review, etc.)
-agents/                       # Expert agents (review, opinion, ask, plan, brainstorm, team implementation)
+agents/                       # 13 expert agents (architect, security, qa, etc.) dispatched by review/opinion/ask/plan/brainstorm/team
 skills/                       # Reusable skills (user-facing auto-triggered + internal referenced by commands)
 hooks/                        # SessionStart hook, workflow rules, config template
 scripts/lets/                 # Statusline + init script (copied/run per-project by /lets:init)
+docs/                         # Plans, knowledge base, reference docs, comment exports
 reference/                    # Reference plugins for studying patterns (gitignored)
 ```
 
 ## Key Concepts
 
 - **Commands** = user-initiated workflows (sessions, commits, reviews)
-- **Agents** = experts dispatched by commands. `/lets:review`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:team`, `/lets:brainstorm` use specialized agents
+- **Agents** = experts dispatched by commands. `/lets:review`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:brainstorm` dispatch via subagents. `/lets:team` dispatches via Agent Teams (parallel, worktree isolation)
 - **Orchestrators** = commands that delegate to other commands. `/lets:pr` orchestrates `/lets:review` for full PR lifecycle
 - **Hooks** = SessionStart injects workflow rules
 - **Statusline** = per-project `.lets/statusline.sh`, source in `scripts/lets/statusline.sh`, copied by `/lets:init`
@@ -26,6 +27,7 @@ reference/                    # Reference plugins for studying patterns (gitigno
 ## Architecture Decisions
 
 - Agents define WHO and HOW (expertise, behavioral modes, tiered scoring, output format). Commands define WHAT and WHEN (provide content, select agents, pass mode name)
+- Agent frontmatter fields: `name`, `description`, `tools`, `color` (terminal output: red/blue/green/yellow/purple/orange/pink/cyan), optional `model` (default inherits from parent, `opus` for complex analysis). All agents use tiered scoring ([BLOCKER]/[SUGGESTION]/[NIT]) and have self-contained Modes sections
 - `/lets:review`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:brainstorm` use `subagent_type: "lets:agent-name"` to dispatch agents via Task tool
 - `/lets:pr` orchestrates `/lets:review` (delegates analysis) and handles GitHub posting, follow-up, respond, and approval directly via gh CLI
 - `/lets:execute` uses EnterPlanMode for native plan mode execution with user approval gates. No subagents.
@@ -101,6 +103,6 @@ Every lets:* command MUST end with branded LETS box:
 
 - [ ] Has LETS box in output section
 - [ ] Updates Skill Quick Reference in `hooks/rules-context.md`
-- [ ] Updates `/lets:install` and `/lets:init` tables
+- [ ] Updates `/lets:install` Essential Skills / Planning Skills tables
 - [ ] Follows session flow (start -> work -> commit -> done -> end)
 - [ ] Description is clear and actionable

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Then start working:
 │  /lets:review    Full multi-agent code review (~2-3 min)                  │
 │                                                                           │
 ├─ You plan, Claude builds ─────────────────────────────────────────────────┤
-│  /lets:brainstorm  Think through what to build - backlog, priorities      │
+│  /lets:brainstorm  Ideation: backlog review, explore ideas, brainstorm    │
 │  /lets:plan        Design how to build it - codebase exploration, arch    │
 │  /lets:execute     Claude implements the plan with your approval gates    │
 │                                                                           │
@@ -149,7 +149,7 @@ Then start working:
 
 | Command | Description |
 |---------|-------------|
-| `/lets:brainstorm` | Interactive backlog helper - because the backlog must grow! |
+| `/lets:brainstorm` | Interactive ideation - backlog review, idea exploration, quick brainstorm, cleanup |
 | `/lets:plan` | Structured planning - explore codebase, design architecture, write plan |
 | `/lets:execute` | Execute plan from `/lets:plan` via native plan mode |
 | `/lets:team` | Parallel implementation with Agent Teams |
@@ -248,6 +248,8 @@ Each teammate gets one task, works in isolation with plan approval from the lead
 | git-historian | Blame analysis, change patterns, refactoring impact |
 | explorer | Codebase structure mapping, pattern identification |
 | implementer | Full-stack implementation in isolated worktrees |
+
+Agents use **tiered scoring** - findings are classified as `[BLOCKER]` (must fix), `[SUGGESTION]` (should fix), or `[NIT]` (nice to have). Each agent operates in context-specific modes (review, opinion, ask, plan, brainstorm) selected by the invoking command.
 
 Agents are read-only - they analyze code but never modify it. Exception: the implementer agent has write access for parallel implementation via `/lets:team`.
 

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,10 +1,9 @@
 ---
 name: architect
-emoji: 🏛️
 description: System design expert for architecture reviews, pattern analysis, SOLID principles evaluation, and coupling/abstraction assessments. Use when reviewing structural changes, evaluating design decisions, or analyzing system architecture.
 tools: Read, Grep, Glob
 model: opus
-color: purple
+color: yellow
 ---
 
 You are a senior software architect with deep expertise in system design, design patterns, and software architecture principles. You evaluate code through the lens of maintainability, extensibility, and clarity. You prefer pragmatic architecture over textbook perfection - a working system with minor imperfections beats an over-engineered "clean" system.

--- a/agents/backend.md
+++ b/agents/backend.md
@@ -1,10 +1,9 @@
 ---
 name: backend
-emoji: 🔧
 description: Backend development expert for API design review, business logic analysis, error handling assessment, and performance evaluation. Use when reviewing server-side code, API endpoints, data processing, or service integrations.
 tools: Read, Grep, Glob, Bash
 model: opus
-color: green
+color: blue
 ---
 
 You are a senior backend developer with broad experience across multiple languages and frameworks (PHP, Python, Node.js, Go, Java, etc.). You focus on correctness first, then performance. You respect the existing codebase's patterns - if the project uses a certain error handling style, new code should match it.

--- a/agents/compliance.md
+++ b/agents/compliance.md
@@ -1,9 +1,8 @@
 ---
 name: compliance
-emoji: 📏
 description: Project standards expert for CLAUDE.md rules compliance, coding conventions adherence, project-specific patterns verification, and style guide enforcement. Use when checking if code follows project rules and established conventions.
 tools: Read, Grep, Glob
-color: red
+color: purple
 ---
 
 You are a project standards auditor who ensures code follows the project's own rules and conventions. You only flag violations of explicit rules or clearly established patterns. You don't invent new rules or enforce general best practices - that's other agents' job.

--- a/agents/database.md
+++ b/agents/database.md
@@ -1,6 +1,5 @@
 ---
 name: database
-emoji: 🗄️
 description: Database expert for schema design review, migration analysis, query optimization, index assessment, and transaction safety. Use when reviewing database schemas, migrations, ORM code, or raw queries.
 tools: Read, Grep, Glob, Bash
 color: orange

--- a/agents/devops.md
+++ b/agents/devops.md
@@ -1,6 +1,5 @@
 ---
 name: devops
-emoji: ⚙️
 description: DevOps and infrastructure expert for Docker review, CI/CD pipeline analysis, deployment configuration, shell script assessment, and infrastructure-as-code evaluation. Use when reviewing Dockerfiles, CI configs, nginx, shell scripts, or deployment setups.
 tools: Read, Grep, Glob, Bash
 color: blue

--- a/agents/docs.md
+++ b/agents/docs.md
@@ -1,9 +1,8 @@
 ---
 name: docs
-emoji: 📝
 description: Documentation expert for API docs review, README assessment, inline documentation analysis, and changelog evaluation. Use when reviewing documentation quality, checking docs-code sync, or evaluating developer onboarding materials.
 tools: Read, Grep, Glob
-color: cyan
+color: green
 ---
 
 You are a senior technical writer with deep experience in developer documentation. You believe good code mostly documents itself. Comments and docs should fill the gaps - the "why", the gotchas, the non-obvious constraints.

--- a/agents/explorer.md
+++ b/agents/explorer.md
@@ -1,6 +1,5 @@
 ---
 name: explorer
-emoji: 🔍
 description: Codebase cartographer for mapping structure, patterns, and integration points relevant to a proposed feature. Use during planning to understand what exists before designing what to add.
 tools: Read, Grep, Glob, Bash
 model: sonnet

--- a/agents/frontend.md
+++ b/agents/frontend.md
@@ -1,6 +1,5 @@
 ---
 name: frontend
-emoji: 🖥️
 description: Frontend development expert for UI component review, state management analysis, accessibility assessment, and bundle optimization. Use when reviewing React, Vue, TypeScript, CSS, or any client-side code.
 tools: Read, Grep, Glob
 color: pink

--- a/agents/git-historian.md
+++ b/agents/git-historian.md
@@ -1,9 +1,8 @@
 ---
 name: git-historian
-emoji: 📜
 description: Git history analyst for blame analysis, past decision context recovery, change pattern detection, and refactoring impact assessment. Use when reviewing changes to existing code that may break established patterns or when historical context is needed.
 tools: Read, Grep, Glob, Bash
-color: yellow
+color: cyan
 ---
 
 You are a codebase historian who understands software through its evolution. You read git history like a story. You use git log, git blame, and git show to uncover context that current code alone doesn't reveal. Past decisions are data points, not sacred rules.

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -1,10 +1,9 @@
 ---
 name: implementer
-emoji: 🔨
 description: Full-stack implementation specialist for isolated worktree work. Follows existing codebase patterns, implements a single task independently with tests. Use for /lets:team parallel implementation.
 tools: Read, Grep, Glob, Bash, Edit, Write
 model: sonnet
-color: orange
+color: green
 ---
 
 You are an implementation specialist working as part of a parallel team.

--- a/agents/pragmatist.md
+++ b/agents/pragmatist.md
@@ -1,9 +1,8 @@
 ---
 name: pragmatist
-emoji: ⚖️
 description: Pragmatic ROI analyst for overengineering detection, effort-vs-value assessment, scope creep identification, and "good enough" evaluation. Use when reviewing large changes, evaluating if a solution is proportional to the problem, or assessing business impact.
 tools: Read, Grep, Glob
-color: yellow
+color: orange
 ---
 
 You are a pragmatic senior developer who cares about shipping value, not writing perfect code.

--- a/agents/qa.md
+++ b/agents/qa.md
@@ -1,9 +1,8 @@
 ---
 name: qa
-emoji: 🧪
 description: QA and testing expert for test strategy review, coverage analysis, assertion quality, mocking patterns, and TDD practices. Use when reviewing test code, evaluating test coverage, or assessing testing strategy.
 tools: Read, Grep, Glob, Bash
-color: green
+color: pink
 ---
 
 You are a senior QA engineer and testing specialist with expertise in test strategy, automation, and quality assurance. You value tests that catch real bugs over tests that inflate coverage numbers. One good integration test can be worth ten shallow unit tests.

--- a/agents/security.md
+++ b/agents/security.md
@@ -1,6 +1,5 @@
 ---
 name: security
-emoji: 🔒
 description: Security specialist for vulnerability detection, auth review, crypto assessment, secrets scanning, and input validation analysis. Use when reviewing security-sensitive code, auth flows, data handling, or API endpoints.
 tools: Read, Grep, Glob, Bash
 model: opus


### PR DESCRIPTION
## Summary
- Update README: brainstorm 4 modes description, tiered scoring for agents, workflow box
- Update CLAUDE.md: agents description (13 not 6), docs/ in structure, agent frontmatter fields, team dispatch clarification
- Fill CHANGELOG [Unreleased] section (PRs #32-#37)
- Remove unused emoji field from all 13 agents
- Reassign agent colors by usage frequency (top-5 frequent get unique colors)

## Test plan
- [ ] Verify agent dispatch still works after emoji removal
- [ ] Verify colors render correctly in terminal

Task: lets-dbuyb

🤖 Generated with [Claude Code](https://claude.com/claude-code)