### PR TITLE
feat: Add beads-web Docker deployment

### DIFF
--- a/scripts/beads-web/README.md
+++ b/scripts/beads-web/README.md
@@ -90,15 +90,13 @@ This rebuilds the Docker image with `--no-cache` (re-downloads the binary) and r
 ### Update workflow
 
 1. Push changes to the fork (`Shybko/beads-web`)
-2. Build the binary (locally or in a Claude session in the fork repo)
-3. Re-upload to the same release tag:
-   ```bash
-   gh release upload v0.9.3 beads-web-linux-x64 --repo Shybko/beads-web --clobber
-   ```
-4. Update VPS:
+2. Create a new release (via GitHub UI or GitHub Actions if configured)
+3. Update VPS:
    ```bash
    ssh root@vps "bash -s" < scripts/beads-web/update-remote.sh
    ```
+
+With `--version latest` (default), the script always downloads from the latest release. No need to specify version numbers.
 
 ### Version upgrade
 
@@ -177,7 +175,7 @@ ssh root@vps "bash -s -- \
 | --dolt-host | dolt | Dolt container hostname |
 | --dolt-port | 3306 | Dolt SQL port |
 | --repo | Shybko/beads-web | GitHub repo for binary |
-| --version | 0.9.3 | beads-web release version |
+| --version | latest | beads-web release version or `latest` |
 
 Either `--allow-ip` or `--no-firewall` is required - board has no built-in auth.
 
@@ -250,9 +248,9 @@ If the DB was lost, re-add projects via API (see Quick Start step 3).
 ### Binary download fails
 
 ```bash
-# Check release URL
-curl -fsSL --head "https://github.com/Shybko/beads-web/releases/download/v0.9.3/beads-web-linux-x64"
-# If 404: check --repo and --version values
+# Check latest release URL
+curl -fsSL --head "https://github.com/Shybko/beads-web/releases/latest/download/beads-web-linux-x64"
+# If 404: check that the repo has at least one release with beads-web-linux-x64 asset
 ```
 
 ### Update doesn't pick up new binary
@@ -260,8 +258,11 @@ curl -fsSL --head "https://github.com/Shybko/beads-web/releases/download/v0.9.3/
 `update-remote.sh` uses `docker compose build --no-cache` to force re-download. If the binary still seems old:
 
 ```bash
+# Check which URL is configured
+grep RELEASE_URL /opt/beads-web/.env
+
 # Verify the release asset was actually updated
-curl -sI "https://github.com/Shybko/beads-web/releases/download/v0.9.3/beads-web-linux-x64" | grep last-modified
+curl -sI "$(grep RELEASE_URL /opt/beads-web/.env | cut -d= -f2-)" | grep last-modified
 
 # Force full rebuild
 cd /opt/beads-web && docker compose down && docker compose build --no-cache && docker compose up -d

--- a/scripts/beads-web/README.md
+++ b/scripts/beads-web/README.md
@@ -2,6 +2,8 @@
 
 Kanban board for beads issue tracker. Rust (Axum) binary with embedded Next.js frontend, runs in Docker, connects to Dolt SQL server.
 
+Source: [Shybko/beads-web](https://github.com/Shybko/beads-web) (fork of weselow/beads-web)
+
 ## Architecture
 
 ```
@@ -12,14 +14,25 @@ http://VPS_IP:9090
 iptables DOCKER-USER (IP allowlist)
      |
 [beads-web container]  --dolt-net-->  [Dolt container]
-   Debian trixie-slim                 MySQL :3306
+   Debian trixie-slim                  MySQL :3306
    Rust binary (beads-web)
+     |
+   Volumes:
+   ./data/.beads/        -> /app/.beads          (metadata.json)
+   ./data/kanban-ui/     -> ~/.local/share/kanban-ui  (projects SQLite DB)
 ```
+
+## Scripts
+
+| Script | Purpose |
+|--------|---------|
+| `setup-remote.sh` | Full install - Docker image, compose, firewall, everything |
+| `update-remote.sh` | Quick update - rebuild image with latest binary, restart |
 
 ## Prerequisites
 
-- Dolt server running in Docker (see scripts/dolt/)
-- dolt-net Docker network (created automatically by setup script)
+- Dolt server running in Docker (see `scripts/dolt/`)
+- `dolt-net` Docker network (created automatically by setup script)
 - SQL user with grants on target database
 
 ## Quick Start
@@ -38,21 +51,67 @@ ssh root@vps "bash -s -- \
   < scripts/beads-web/setup-remote.sh
 ```
 
-### 3. Open in browser
+### 3. Add projects
+
+beads-web supports multiple Dolt databases as separate projects. After deploy, add them via API:
+
+```bash
+# Add a project (from VPS)
+docker exec beads-web curl -sf -X POST http://localhost:9090/api/projects \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"my-project","path":"dolt://mydb"}'
+
+# Add another project
+docker exec beads-web curl -sf -X POST http://localhost:9090/api/projects \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"another-project","path":"dolt://anotherdb"}'
+```
+
+The `dolt://` prefix tells beads-web to read/write via Dolt SQL. Each database on the Dolt server can be a separate project.
+
+> **Note:** The UI "Add Project" button currently only supports local paths. Remote Dolt databases must be added via API. See [Shybko/beads-web#3](https://github.com/Shybko/beads-web/issues/3) for UI support progress.
+
+### 4. Open in browser
 
 ```
 http://VPS_IP:9090
 ```
 
-## Adding Another Database
+## Updating
+
+When the fork has new changes (binary re-uploaded to the same release tag):
+
+```bash
+ssh root@vps "bash -s" < scripts/beads-web/update-remote.sh
+```
+
+This rebuilds the Docker image with `--no-cache` (re-downloads the binary) and restarts the container. Project configuration (SQLite DB) is preserved via volume mount.
+
+### Update workflow
+
+1. Push changes to the fork (`Shybko/beads-web`)
+2. Build the binary (locally or in a Claude session in the fork repo)
+3. Re-upload to the same release tag:
+   ```bash
+   gh release upload v0.9.3 beads-web-linux-x64 --repo Shybko/beads-web --clobber
+   ```
+4. Update VPS:
+   ```bash
+   ssh root@vps "bash -s" < scripts/beads-web/update-remote.sh
+   ```
+
+### Version upgrade
+
+To upgrade to a new version (new release tag):
 
 ```bash
 ssh root@vps "bash -s -- \
   --sql-user bdweb --sql-password your-password \
-  --database aff --port 9091 \
-  --install-dir /opt/beads-web-aff \
-  --allow-ip YOUR_IP" < scripts/beads-web/setup-remote.sh
+  --database lets --port 9090 \
+  --version 1.0.0" < scripts/beads-web/setup-remote.sh
 ```
+
+The setup script is idempotent - it regenerates config and rebuilds the container.
 
 ## IP Allowlist
 
@@ -66,16 +125,13 @@ ssh root@vps "bash -s -- --remove-ip 1.2.3.4 --port 9090" \
   < scripts/beads-web/setup-remote.sh
 ```
 
-## Upgrading
+Multiple IPs can be added in a single command:
 
 ```bash
 ssh root@vps "bash -s -- \
-  --sql-user bdweb --sql-password your-password \
-  --database lets --port 9090 \
-  --version 1.0.0" < scripts/beads-web/setup-remote.sh
+  --allow-ip 1.2.3.4 --allow-ip 5.6.7.8 --allow-ip 9.10.11.12 \
+  --port 9090" < scripts/beads-web/setup-remote.sh
 ```
-
-The script is idempotent - it rebuilds the container with the new version.
 
 ## Fork Support
 
@@ -92,24 +148,28 @@ ssh root@vps "bash -s -- \
 ## Server Layout
 
 ```
-/opt/beads-web/              # Default install dir
-├── .env                     # Credentials (chmod 600)
+/opt/beads-web/                # Default install dir
+├── .env                       # Credentials (chmod 600)
 ├── docker-compose.yml
 ├── Dockerfile
 └── data/
-    └── .beads/
-        └── metadata.json    # Database: lets
+    ├── .beads/
+    │   └── metadata.json      # Dolt database config
+    └── kanban-ui/
+        └── settings.db        # Projects & tags (SQLite, persisted via volume)
 ```
 
 ## CLI Reference
+
+### setup-remote.sh
 
 **Full install** (all required):
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| --sql-user | - | SQL username |
+| --sql-user | - | SQL username for Dolt connection |
 | --sql-password | - | SQL password |
-| --database | - | Dolt database name |
+| --database | - | Dolt database name (e.g., lets, aff) |
 | --allow-ip | - | Restrict access to this IP (repeatable) |
 | --no-firewall | - | Leave port open to all (NOT recommended) |
 | --port | 9090 | Web UI port |
@@ -129,22 +189,32 @@ Either `--allow-ip` or `--no-firewall` is required - board has no built-in auth.
 | --remove-ip | - | Remove IP from allowlist |
 | --port | 9090 | Target port |
 
+### update-remote.sh
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| --install-dir | /opt/beads-web | Installation directory |
+
+Reads repo and version from existing `.env` file. No other arguments needed.
+
 ## Security
 
 - **No built-in auth** - access controlled via IP allowlist (iptables)
 - **No TLS** - use SSH tunnel for encrypted access if needed
-- Credentials stored in .env (chmod 600, root-only)
+- Credentials stored in `.env` (chmod 600, root-only)
 - Container runs as non-root user (beadsweb, uid 1000)
 - SQL user should have minimal grants (per-database only)
 
 ## Troubleshooting
 
 ### Container won't start
+
 ```bash
 cd /opt/beads-web && docker compose logs
 ```
 
 ### Can't connect to Dolt
+
 ```bash
 # Check dolt-net connectivity
 docker exec beads-web curl -sf http://dolt:3306 || echo "No connection"
@@ -152,32 +222,47 @@ docker network inspect dolt-net
 ```
 
 ### Port not accessible
+
 ```bash
 iptables -L DOCKER-USER -n | grep 9090
 # Ensure your IP is in the allowlist
 ```
 
-### Adding a remote Dolt database (project)
+### Projects disappeared after update
 
-The UI "Add Project" dialog currently only supports local filesystem paths. To add a remote Dolt database, use the API directly:
+Projects are stored in SQLite at `data/kanban-ui/settings.db`, mounted as a Docker volume. If projects are missing after an update:
 
 ```bash
-# Add a project pointing to a Dolt database
-docker exec beads-web curl -sf -X POST http://localhost:9090/api/projects \
-  -H 'Content-Type: application/json' \
-  -d '{"name":"my-project","path":"dolt://mydb"}'
+# Check if the volume mount exists
+docker inspect beads-web | grep -A 2 kanban-ui
 
-# List all projects
-docker exec beads-web curl -sf http://localhost:9090/api/projects
+# Check if the DB file exists on host
+ls -la /opt/beads-web/data/kanban-ui/settings.db
 ```
 
-The `dolt://` prefix tells beads-web to read/write beads via Dolt SQL instead of the filesystem. Multiple databases on the same Dolt server can each be added as a separate project.
+If the DB file exists but isn't mounted, recreate the container:
+```bash
+cd /opt/beads-web && docker compose down && docker compose up -d
+```
 
-See [Shybko/beads-web#3](https://github.com/Shybko/beads-web/issues/3) for UI support progress.
+If the DB was lost, re-add projects via API (see Quick Start step 3).
 
 ### Binary download fails
+
 ```bash
 # Check release URL
 curl -fsSL --head "https://github.com/Shybko/beads-web/releases/download/v0.9.3/beads-web-linux-x64"
 # If 404: check --repo and --version values
+```
+
+### Update doesn't pick up new binary
+
+`update-remote.sh` uses `docker compose build --no-cache` to force re-download. If the binary still seems old:
+
+```bash
+# Verify the release asset was actually updated
+curl -sI "https://github.com/Shybko/beads-web/releases/download/v0.9.3/beads-web-linux-x64" | grep last-modified
+
+# Force full rebuild
+cd /opt/beads-web && docker compose down && docker compose build --no-cache && docker compose up -d
 ```

--- a/scripts/beads-web/README.md
+++ b/scripts/beads-web/README.md
@@ -1,0 +1,165 @@
+# beads-web - Kanban Board
+
+Kanban board for beads issue tracker. Rust (Axum) binary with embedded Next.js frontend, runs in Docker, connects to Dolt SQL server.
+
+## Architecture
+
+```
+Developer browser
+     |
+http://VPS_IP:9090
+     |
+iptables DOCKER-USER (IP allowlist)
+     |
+[beads-web container]  --dolt-net-->  [Dolt container]
+   Debian trixie-slim                 MySQL :3306
+   Rust binary (beads-web)
+```
+
+## Prerequisites
+
+- Dolt server running in Docker (see scripts/dolt/)
+- dolt-net Docker network (created automatically by setup script)
+- SQL user with grants on target database
+
+## Quick Start
+
+### 1. Create SQL user in Dolt (if not exists)
+
+See [scripts/dolt/README.md - Add SQL user](../dolt/README.md#add-sql-user).
+
+### 2. Deploy beads-web
+
+```bash
+ssh root@vps "bash -s -- \
+  --sql-user bdweb --sql-password your-password \
+  --database lets --port 9090 \
+  --allow-ip YOUR_IP_1 --allow-ip YOUR_IP_2" \
+  < scripts/beads-web/setup-remote.sh
+```
+
+### 3. Open in browser
+
+```
+http://VPS_IP:9090
+```
+
+## Adding Another Database
+
+```bash
+ssh root@vps "bash -s -- \
+  --sql-user bdweb --sql-password your-password \
+  --database aff --port 9091 \
+  --install-dir /opt/beads-web-aff \
+  --allow-ip YOUR_IP" < scripts/beads-web/setup-remote.sh
+```
+
+## IP Allowlist
+
+```bash
+# Add IP
+ssh root@vps "bash -s -- --allow-ip 1.2.3.4 --port 9090" \
+  < scripts/beads-web/setup-remote.sh
+
+# Remove IP
+ssh root@vps "bash -s -- --remove-ip 1.2.3.4 --port 9090" \
+  < scripts/beads-web/setup-remote.sh
+```
+
+## Upgrading
+
+```bash
+ssh root@vps "bash -s -- \
+  --sql-user bdweb --sql-password your-password \
+  --database lets --port 9090 \
+  --version 1.0.0" < scripts/beads-web/setup-remote.sh
+```
+
+The script is idempotent - it rebuilds the container with the new version.
+
+## Fork Support
+
+By default, the binary is downloaded from `Shybko/beads-web`. Use `--repo` to specify a different fork:
+
+```bash
+ssh root@vps "bash -s -- \
+  --sql-user bdweb --sql-password your-password \
+  --database lets --port 9090 \
+  --repo weselow/beads-web --version 1.0.0 \
+  --allow-ip YOUR_IP" < scripts/beads-web/setup-remote.sh
+```
+
+## Server Layout
+
+```
+/opt/beads-web/              # Default install dir
+├── .env                     # Credentials (chmod 600)
+├── docker-compose.yml
+├── Dockerfile
+└── data/
+    └── .beads/
+        └── metadata.json    # Database: lets
+```
+
+## CLI Reference
+
+**Full install** (all required):
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| --sql-user | - | SQL username |
+| --sql-password | - | SQL password |
+| --database | - | Dolt database name |
+| --allow-ip | - | Restrict access to this IP (repeatable) |
+| --no-firewall | - | Leave port open to all (NOT recommended) |
+| --port | 9090 | Web UI port |
+| --install-dir | /opt/beads-web | Installation directory |
+| --dolt-host | dolt | Dolt container hostname |
+| --dolt-port | 3306 | Dolt SQL port |
+| --repo | Shybko/beads-web | GitHub repo for binary |
+| --version | 0.9.3 | beads-web release version |
+
+Either `--allow-ip` or `--no-firewall` is required - board has no built-in auth.
+
+**IP management** (standalone, without --database):
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| --allow-ip | - | Add IP to allowlist |
+| --remove-ip | - | Remove IP from allowlist |
+| --port | 9090 | Target port |
+
+## Security
+
+- **No built-in auth** - access controlled via IP allowlist (iptables)
+- **No TLS** - use SSH tunnel for encrypted access if needed
+- Credentials stored in .env (chmod 600, root-only)
+- Container runs as non-root user (beadsweb, uid 1000)
+- SQL user should have minimal grants (per-database only)
+
+## Troubleshooting
+
+### Container won't start
+```bash
+cd /opt/beads-web && docker compose logs
+```
+
+### Can't connect to Dolt
+```bash
+# Check dolt-net connectivity
+docker exec beads-web curl -sf http://dolt:3306 || echo "No connection"
+docker network inspect dolt-net
+```
+
+### Port not accessible
+```bash
+iptables -L DOCKER-USER -n | grep 9090
+# Ensure your IP is in the allowlist
+```
+
+### Binary download fails
+```bash
+# Check release URL
+curl -fsSL --head "https://github.com/Shybko/beads-web/releases/download/v0.9.3/beads-web-linux-x64"
+# If 404: check --repo and --version values
+```

--- a/scripts/beads-web/README.md
+++ b/scripts/beads-web/README.md
@@ -157,6 +157,24 @@ iptables -L DOCKER-USER -n | grep 9090
 # Ensure your IP is in the allowlist
 ```
 
+### Adding a remote Dolt database (project)
+
+The UI "Add Project" dialog currently only supports local filesystem paths. To add a remote Dolt database, use the API directly:
+
+```bash
+# Add a project pointing to a Dolt database
+docker exec beads-web curl -sf -X POST http://localhost:9090/api/projects \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"my-project","path":"dolt://mydb"}'
+
+# List all projects
+docker exec beads-web curl -sf http://localhost:9090/api/projects
+```
+
+The `dolt://` prefix tells beads-web to read/write beads via Dolt SQL instead of the filesystem. Multiple databases on the same Dolt server can each be added as a separate project.
+
+See [Shybko/beads-web#3](https://github.com/Shybko/beads-web/issues/3) for UI support progress.
+
 ### Binary download fails
 ```bash
 # Check release URL

--- a/scripts/beads-web/setup-remote.sh
+++ b/scripts/beads-web/setup-remote.sh
@@ -275,8 +275,8 @@ create_network() {
 # ============================================
 create_config() {
   echo -e "${YELLOW}[2/4] Creating configuration...${NC}"
-  mkdir -p "$INSTALL_DIR/data/.beads"
-  # Container runs as beadsweb (uid 1000) - data dir must be writable
+  mkdir -p "$INSTALL_DIR/data/.beads" "$INSTALL_DIR/data/kanban-ui"
+  # Container runs as beadsweb (uid 1000) - data dirs must be writable
   chown -R 1000:1000 "$INSTALL_DIR/data"
 
   # Dockerfile
@@ -324,6 +324,7 @@ services:
       - "\${BEADS_WEB_PORT:-9090}:\${BEADS_WEB_PORT:-9090}"
     volumes:
       - ./data/.beads:/app/.beads
+      - ./data/kanban-ui:/home/beadsweb/.local/share/kanban-ui
     environment:
       - PORT=\${BEADS_WEB_PORT:-9090}
       - DOLT_HOST=\${DOLT_HOST:-dolt}

--- a/scripts/beads-web/setup-remote.sh
+++ b/scripts/beads-web/setup-remote.sh
@@ -1,0 +1,469 @@
+#!/bin/bash
+# beads-web - Kanban Board Docker Installation
+# Deploys beads-web container (Rust binary) that connects to existing Dolt server via Docker network.
+#
+# Usage:
+#   # Full install
+#   ssh root@vps "bash -s -- \
+#     --sql-user bdweb --sql-password secret \
+#     --database lets --port 9090 \
+#     --allow-ip 1.2.3.4 --allow-ip 5.6.7.8" < scripts/beads-web/setup-remote.sh
+#
+#   # Different database on different port
+#   ssh root@vps "bash -s -- \
+#     --sql-user bdweb --sql-password secret \
+#     --database aff --port 9091 \
+#     --install-dir /opt/beads-web-aff \
+#     --allow-ip 1.2.3.4" < scripts/beads-web/setup-remote.sh
+#
+#   # Custom fork
+#   ssh root@vps "bash -s -- \
+#     --sql-user bdweb --sql-password secret \
+#     --database lets --port 9090 \
+#     --repo weselow/beads-web --version 1.0.0 \
+#     --allow-ip 1.2.3.4" < scripts/beads-web/setup-remote.sh
+#
+#   # Manage IP allowlist
+#   ssh root@vps "bash -s -- --allow-ip 1.2.3.4 --port 9090" < scripts/beads-web/setup-remote.sh
+#   ssh root@vps "bash -s -- --remove-ip 1.2.3.4 --port 9090" < scripts/beads-web/setup-remote.sh
+#
+# Prerequisites:
+#   - Docker installed (use scripts/dolt/setup-remote.sh first)
+#   - Dolt container running with dolt-net network
+#   - SQL user created in Dolt with grants on target database
+
+set -e
+
+# ============================================
+# Configuration
+# ============================================
+INSTALL_DIR="${INSTALL_DIR:-/opt/beads-web}"
+BEADS_WEB_PORT="${BEADS_WEB_PORT:-9090}"
+BEADS_WEB_VERSION="${BEADS_WEB_VERSION:-0.9.3}"
+BEADS_WEB_REPO="${BEADS_WEB_REPO:-Shybko/beads-web}"
+DOLT_HOST="${DOLT_HOST:-dolt}"
+DOLT_PORT="${DOLT_PORT:-3306}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================
+# Helpers
+# ============================================
+validate_name() {
+  local value="$1" label="$2"
+  if [[ ! "$value" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+    echo -e "${RED}Error: ${label} must be alphanumeric (a-z, 0-9, _, -)${NC}"
+    exit 1
+  fi
+}
+
+validate_ip() {
+  local ip="$1"
+  if [[ ! "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?$ ]]; then
+    echo -e "${RED}Error: Invalid IP address format: $ip${NC}"
+    exit 1
+  fi
+  # Validate octets
+  local addr cidr
+  IFS='/' read -r addr cidr <<< "$ip"
+  IFS='.' read -ra octets <<< "$addr"
+  for o in "${octets[@]}"; do
+    if (( o > 255 )); then
+      echo -e "${RED}Error: Invalid IP octet: $o in $ip${NC}"
+      exit 1
+    fi
+  done
+  # Block wide CIDR ranges
+  if [[ -n "$cidr" ]] && (( cidr < 24 )); then
+    echo -e "${RED}Error: CIDR mask /$cidr is too wide (minimum /24)${NC}"
+    exit 1
+  fi
+  if [[ "$ip" == "0.0.0.0/0" || "$ip" == "0.0.0.0" ]]; then
+    echo -e "${RED}Error: Refusing 0.0.0.0 - this would open the port to everyone${NC}"
+    exit 1
+  fi
+}
+
+# ============================================
+# Parse args
+# ============================================
+SQL_USER=""
+SQL_PASSWORD=""
+DATABASE=""
+ALLOW_IPS=()
+REMOVE_IP=""
+NO_FIREWALL=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --sql-user) SQL_USER="$2"; shift 2 ;;
+    --sql-password) SQL_PASSWORD="$2"; shift 2 ;;
+    --database) DATABASE="$2"; shift 2 ;;
+    --port) BEADS_WEB_PORT="$2"; shift 2 ;;
+    --install-dir) INSTALL_DIR="$2"; shift 2 ;;
+    --dolt-host) DOLT_HOST="$2"; shift 2 ;;
+    --dolt-port) DOLT_PORT="$2"; shift 2 ;;
+    --repo) BEADS_WEB_REPO="$2"; shift 2 ;;
+    --version) BEADS_WEB_VERSION="$2"; shift 2 ;;
+    --allow-ip) ALLOW_IPS+=("$2"); shift 2 ;;
+    --remove-ip) REMOVE_IP="$2"; shift 2 ;;
+    --no-firewall) NO_FIREWALL=true; shift ;;
+    --) shift ;;
+    *) echo -e "${RED}Unknown argument: $1${NC}"; exit 1 ;;
+  esac
+done
+
+# ============================================
+# IP allowlist management
+# ============================================
+manage_ip_allowlist() {
+  local action="$1" ip="$2" port="$BEADS_WEB_PORT"
+
+  if ! dpkg -s iptables-persistent &>/dev/null; then
+    echo "Installing iptables-persistent..."
+    DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
+  fi
+
+  if [[ "$action" == "add" ]]; then
+    if iptables -C DOCKER-USER -p tcp --dport "$port" -s "$ip" -j ACCEPT 2>/dev/null; then
+      echo -e "${YELLOW}IP $ip already allowed on port $port${NC}"
+      return 0
+    fi
+    iptables -I DOCKER-USER -p tcp --dport "$port" -s "$ip" -j ACCEPT
+    echo -e "${GREEN}Allowed IP: $ip on port $port${NC}"
+  elif [[ "$action" == "remove" ]]; then
+    iptables -D DOCKER-USER -p tcp --dport "$port" -s "$ip" -j ACCEPT 2>/dev/null || true
+    echo -e "${GREEN}Removed IP: $ip from port $port${NC}"
+  fi
+
+  # Ensure REJECT rule exists at end (tcp-reset gives immediate "Connection refused")
+  if ! iptables -C DOCKER-USER -p tcp --dport "$port" -j REJECT --reject-with tcp-reset 2>/dev/null; then
+    # Remove old DROP rule if exists (upgrade path)
+    iptables -D DOCKER-USER -p tcp --dport "$port" -j DROP 2>/dev/null || true
+    iptables -A DOCKER-USER -p tcp --dport "$port" -j REJECT --reject-with tcp-reset
+  fi
+
+  # Block IPv6 for this port
+  if ! ip6tables -C DOCKER-USER -p tcp --dport "$port" -j REJECT --reject-with tcp-reset 2>/dev/null; then
+    ip6tables -D DOCKER-USER -p tcp --dport "$port" -j DROP 2>/dev/null || true
+    ip6tables -A DOCKER-USER -p tcp --dport "$port" -j REJECT --reject-with tcp-reset
+  fi
+
+  netfilter-persistent save 2>/dev/null || iptables-save > /etc/iptables/rules.v4
+
+  echo ""
+  echo "Current allowlist for port $port:"
+  iptables -L DOCKER-USER -n --line-numbers 2>/dev/null | grep -E "dpt:$port|Chain"
+}
+
+# --remove-ip mode (standalone)
+if [[ -n "$REMOVE_IP" ]]; then
+  validate_ip "$REMOVE_IP"
+  manage_ip_allowlist "remove" "$REMOVE_IP"
+  exit 0
+fi
+
+# --allow-ip only mode (no --database = just manage firewall)
+if [[ ${#ALLOW_IPS[@]} -gt 0 && -z "$DATABASE" ]]; then
+  for ip in "${ALLOW_IPS[@]}"; do
+    validate_ip "$ip"
+    manage_ip_allowlist "add" "$ip"
+  done
+  exit 0
+fi
+
+# ============================================
+# Validate
+# ============================================
+if [ "$EUID" -ne 0 ]; then
+  echo -e "${RED}Error: Please run as root${NC}"
+  exit 1
+fi
+
+if ! command -v docker &>/dev/null || ! docker info &>/dev/null; then
+  echo -e "${RED}Error: Docker not installed or not running. Run scripts/dolt/setup-remote.sh first.${NC}"
+  exit 1
+fi
+
+if [[ -z "$DATABASE" ]]; then
+  echo "Modes:"
+  echo "  Full install:   $0 --sql-user USER --sql-password PASS --database DB --allow-ip IP"
+  echo "  Add IP:         $0 --allow-ip IP --port PORT"
+  echo "  Remove IP:      $0 --remove-ip IP --port PORT"
+  echo ""
+  echo "Full install:"
+  echo "  --sql-user USER        SQL username for Dolt connection"
+  echo "  --sql-password PASS    SQL password"
+  echo "  --database DB          Dolt database name (e.g., lets, aff)"
+  echo "  --allow-ip IP          Restrict access to this IP (repeatable)"
+  echo "  --no-firewall          Leave port open to all (NOT recommended)"
+  echo ""
+  echo "  Optional:"
+  echo "  --port PORT            Web UI port (default: 9090)"
+  echo "  --install-dir DIR      Install directory (default: /opt/beads-web)"
+  echo "  --dolt-host HOST       Dolt hostname (default: dolt)"
+  echo "  --dolt-port PORT       Dolt SQL port (default: 3306)"
+  echo "  --repo OWNER/REPO      GitHub repo for binary (default: Shybko/beads-web)"
+  echo "  --version VER          beads-web version (default: 0.9.3)"
+  echo ""
+  echo "IP management (standalone):"
+  echo "  --allow-ip IP          Add IP to allowlist"
+  echo "  --remove-ip IP         Remove IP from allowlist"
+  echo "  --port PORT            Target port (default: 9090)"
+  exit 1
+fi
+
+if [[ -z "$SQL_USER" || -z "$SQL_PASSWORD" ]]; then
+  echo -e "${RED}Error: --sql-user and --sql-password are required${NC}"
+  exit 1
+fi
+
+validate_name "$DATABASE" "Database"
+validate_name "$SQL_USER" "SQL user"
+
+# Resolve versions from existing .env
+if [[ -f "$INSTALL_DIR/.env" ]]; then
+  echo -e "${YELLOW}Existing installation found at $INSTALL_DIR${NC}"
+  existing_version=$(grep '^BEADS_WEB_VERSION=' "$INSTALL_DIR/.env" | cut -d= -f2)
+  existing_repo=$(grep '^BEADS_WEB_REPO=' "$INSTALL_DIR/.env" | cut -d= -f2)
+  BEADS_WEB_VERSION="${BEADS_WEB_VERSION:-$existing_version}"
+  BEADS_WEB_REPO="${BEADS_WEB_REPO:-$existing_repo}"
+fi
+
+# Build release URL
+RELEASE_URL="https://github.com/${BEADS_WEB_REPO}/releases/download/v${BEADS_WEB_VERSION}/beads-web-linux-x64"
+
+echo ""
+echo -e "${GREEN}=== beads-web Kanban Board Setup ===${NC}"
+echo -e "${GREEN}    Docker + Dolt Network${NC}"
+echo ""
+echo "  Database:    $DATABASE"
+echo "  Port:        $BEADS_WEB_PORT"
+echo "  Install dir: $INSTALL_DIR"
+echo "  Repo:        $BEADS_WEB_REPO"
+echo "  Version:     $BEADS_WEB_VERSION"
+echo "  Binary URL:  $RELEASE_URL"
+echo ""
+
+# ============================================
+# 1. Create Docker network
+# ============================================
+create_network() {
+  echo -e "${YELLOW}[1/4] Setting up Docker network...${NC}"
+
+  docker network create dolt-net 2>/dev/null && echo "  Created dolt-net network" || echo "  dolt-net network exists"
+
+  # Connect Dolt container if not already connected
+  if docker inspect dolt --format '{{range $net, $_ := .NetworkSettings.Networks}}{{$net}} {{end}}' 2>/dev/null | grep -q dolt-net; then
+    echo "  Dolt container already on dolt-net"
+  else
+    if docker ps --format '{{.Names}}' | grep -q '^dolt$'; then
+      docker network connect dolt-net dolt
+      echo "  Connected Dolt container to dolt-net"
+    else
+      echo -e "${YELLOW}  Warning: Dolt container not running. Start Dolt first, then re-run.${NC}"
+    fi
+  fi
+}
+
+# ============================================
+# 2. Create configuration
+# ============================================
+create_config() {
+  echo -e "${YELLOW}[2/4] Creating configuration...${NC}"
+  mkdir -p "$INSTALL_DIR/data/.beads"
+  # Container runs as beadsweb (uid 1000) - data dir must be writable
+  chown -R 1000:1000 "$INSTALL_DIR/data"
+
+  # Dockerfile
+  cat > "$INSTALL_DIR/Dockerfile" <<'DOCKERFILE'
+FROM debian:trixie-slim
+
+ARG BEADS_WEB_VERSION=0.9.3
+ARG BEADS_WEB_REPO=Shybko/beads-web
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fSL -o /usr/local/bin/beads-web \
+    "https://github.com/${BEADS_WEB_REPO}/releases/download/v${BEADS_WEB_VERSION}/beads-web-linux-x64" \
+    && chmod +x /usr/local/bin/beads-web
+
+RUN useradd --uid 1000 --system --create-home beadsweb \
+    && mkdir -p /app/.beads && chown -R beadsweb:beadsweb /app
+
+WORKDIR /app
+USER beadsweb
+
+EXPOSE 9090
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=10s \
+  CMD curl -sf http://localhost:${PORT:-9090}/ || exit 1
+
+CMD ["beads-web"]
+DOCKERFILE
+
+  # docker-compose.yml
+  cat > "$INSTALL_DIR/docker-compose.yml" <<EOF
+services:
+  beads-web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        BEADS_WEB_VERSION: \${BEADS_WEB_VERSION:-0.9.3}
+        BEADS_WEB_REPO: \${BEADS_WEB_REPO:-Shybko/beads-web}
+    container_name: beads-web
+    restart: unless-stopped
+    ports:
+      - "\${BEADS_WEB_PORT:-9090}:\${BEADS_WEB_PORT:-9090}"
+    volumes:
+      - ./data/.beads:/app/.beads
+    environment:
+      - PORT=\${BEADS_WEB_PORT:-9090}
+      - DOLT_HOST=\${DOLT_HOST:-dolt}
+      - DOLT_PORT=\${DOLT_PORT:-3306}
+      - DOLT_USER=\${SQL_USER}
+      - DOLT_PASSWORD=\${SQL_PASSWORD}
+      - NO_BROWSER=1
+    networks:
+      - dolt-net
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: "1.0"
+        reservations:
+          memory: 64M
+
+networks:
+  dolt-net:
+    external: true
+EOF
+
+  # metadata.json
+  cat > "$INSTALL_DIR/data/.beads/metadata.json" <<EOF
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "dolt_database": "${DATABASE}"
+}
+EOF
+
+  # .env
+  cat > "$INSTALL_DIR/.env" <<EOF
+# Generated by setup-remote.sh
+SQL_USER='${SQL_USER}'
+SQL_PASSWORD='${SQL_PASSWORD}'
+DATABASE=${DATABASE}
+BEADS_WEB_PORT=${BEADS_WEB_PORT}
+BEADS_WEB_VERSION=${BEADS_WEB_VERSION}
+BEADS_WEB_REPO=${BEADS_WEB_REPO}
+DOLT_HOST=${DOLT_HOST}
+DOLT_PORT=${DOLT_PORT}
+EOF
+  chmod 600 "$INSTALL_DIR/.env"
+
+  echo "  Config written to $INSTALL_DIR/"
+}
+
+# ============================================
+# 3. Build and start
+# ============================================
+build_and_start() {
+  echo -e "${YELLOW}[3/4] Building and starting beads-web...${NC}"
+
+  # Validate release URL before building
+  echo "  Checking release URL..."
+  if ! curl -fsSL --head "$RELEASE_URL" >/dev/null 2>&1; then
+    echo -e "${RED}ERROR: Release not found at: $RELEASE_URL${NC}"
+    echo -e "${RED}Check --repo and --version values.${NC}"
+    exit 1
+  fi
+  echo "  Release URL valid"
+
+  cd "$INSTALL_DIR"
+  docker compose build
+  docker compose up -d
+  sleep 5
+
+  if docker compose ps --format '{{.Status}}' | grep -q "Up"; then
+    echo "  beads-web running on port $BEADS_WEB_PORT"
+  else
+    echo -e "${RED}ERROR: beads-web failed to start. Check: docker compose -f $INSTALL_DIR/docker-compose.yml logs${NC}"
+    exit 1
+  fi
+}
+
+# ============================================
+# 4. Setup firewall
+# ============================================
+setup_firewall() {
+  echo -e "${YELLOW}[4/4] Setting up firewall...${NC}"
+
+  if [[ "$NO_FIREWALL" == true ]]; then
+    echo -e "${YELLOW}  --no-firewall: skipping IP allowlist. Port $BEADS_WEB_PORT is open to all.${NC}"
+    return 0
+  fi
+
+  if [[ ${#ALLOW_IPS[@]} -eq 0 ]]; then
+    echo -e "${RED}Error: --allow-ip is required (board has no auth). Use --no-firewall to explicitly skip.${NC}"
+    exit 1
+  fi
+
+  for ip in "${ALLOW_IPS[@]}"; do
+    validate_ip "$ip"
+    manage_ip_allowlist "add" "$ip"
+  done
+}
+
+# ============================================
+# Summary
+# ============================================
+print_summary() {
+  PUBLIC_IP=$(curl -s ifconfig.me 2>/dev/null || hostname -I | awk '{print $1}')
+
+  echo ""
+  echo -e "${GREEN}========================================${NC}"
+  echo -e "${GREEN}    beads-web Kanban Board Ready${NC}"
+  echo -e "${GREEN}========================================${NC}"
+  echo ""
+  echo "  URL:          http://$PUBLIC_IP:$BEADS_WEB_PORT"
+  echo "  Database:     $DATABASE"
+  echo "  Container:    beads-web"
+  echo "  Install dir:  $INSTALL_DIR"
+  echo "  Repo:         $BEADS_WEB_REPO"
+  echo "  Version:      $BEADS_WEB_VERSION"
+  echo ""
+  echo "Manage:"
+  echo "  Logs:         docker logs beads-web"
+  echo "  Restart:      cd $INSTALL_DIR && docker compose restart"
+  echo "  Stop:         cd $INSTALL_DIR && docker compose down"
+  echo ""
+  echo "IP allowlist:"
+  echo "  --allow-ip <IP> --port $BEADS_WEB_PORT"
+  echo "  --remove-ip <IP> --port $BEADS_WEB_PORT"
+  echo ""
+  echo "Add another database:"
+  echo "  $0 --sql-user USER --sql-password PASS \\"
+  echo "    --database aff --port 9091 \\"
+  echo "    --install-dir /opt/beads-web-aff \\"
+  echo "    --allow-ip <IP>"
+  echo ""
+  echo -e "${GREEN}========================================${NC}"
+}
+
+# ============================================
+# Main
+# ============================================
+create_network
+create_config
+build_and_start
+setup_firewall
+print_summary

--- a/scripts/beads-web/setup-remote.sh
+++ b/scripts/beads-web/setup-remote.sh
@@ -39,7 +39,7 @@ set -e
 # ============================================
 INSTALL_DIR="${INSTALL_DIR:-/opt/beads-web}"
 BEADS_WEB_PORT="${BEADS_WEB_PORT:-9090}"
-BEADS_WEB_VERSION="${BEADS_WEB_VERSION:-0.9.3}"
+BEADS_WEB_VERSION="${BEADS_WEB_VERSION:-latest}"
 BEADS_WEB_REPO="${BEADS_WEB_REPO:-Shybko/beads-web}"
 DOLT_HOST="${DOLT_HOST:-dolt}"
 DOLT_PORT="${DOLT_PORT:-3306}"
@@ -208,7 +208,7 @@ if [[ -z "$DATABASE" ]]; then
   echo "  --dolt-host HOST       Dolt hostname (default: dolt)"
   echo "  --dolt-port PORT       Dolt SQL port (default: 3306)"
   echo "  --repo OWNER/REPO      GitHub repo for binary (default: Shybko/beads-web)"
-  echo "  --version VER          beads-web version (default: 0.9.3)"
+  echo "  --version VER          beads-web version or 'latest' (default: latest)"
   echo ""
   echo "IP management (standalone):"
   echo "  --allow-ip IP          Add IP to allowlist"
@@ -235,7 +235,11 @@ if [[ -f "$INSTALL_DIR/.env" ]]; then
 fi
 
 # Build release URL
-RELEASE_URL="https://github.com/${BEADS_WEB_REPO}/releases/download/v${BEADS_WEB_VERSION}/beads-web-linux-x64"
+if [[ "$BEADS_WEB_VERSION" == "latest" ]]; then
+  RELEASE_URL="https://github.com/${BEADS_WEB_REPO}/releases/latest/download/beads-web-linux-x64"
+else
+  RELEASE_URL="https://github.com/${BEADS_WEB_REPO}/releases/download/v${BEADS_WEB_VERSION}/beads-web-linux-x64"
+fi
 
 echo ""
 echo -e "${GREEN}=== beads-web Kanban Board Setup ===${NC}"
@@ -280,18 +284,16 @@ create_config() {
   chown -R 1000:1000 "$INSTALL_DIR/data"
 
   # Dockerfile
-  cat > "$INSTALL_DIR/Dockerfile" <<'DOCKERFILE'
+  cat > "$INSTALL_DIR/Dockerfile" <<DOCKERFILE
 FROM debian:trixie-slim
 
-ARG BEADS_WEB_VERSION=0.9.3
-ARG BEADS_WEB_REPO=Shybko/beads-web
+ARG RELEASE_URL=${RELEASE_URL}
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl ca-certificates \
+RUN apt-get update && apt-get install -y --no-install-recommends \\
+    curl ca-certificates \\
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fSL -o /usr/local/bin/beads-web \
-    "https://github.com/${BEADS_WEB_REPO}/releases/download/v${BEADS_WEB_VERSION}/beads-web-linux-x64" \
+RUN curl -fSL -o /usr/local/bin/beads-web "\${RELEASE_URL}" \\
     && chmod +x /usr/local/bin/beads-web
 
 RUN useradd --uid 1000 --system --create-home beadsweb \
@@ -316,8 +318,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        BEADS_WEB_VERSION: \${BEADS_WEB_VERSION:-0.9.3}
-        BEADS_WEB_REPO: \${BEADS_WEB_REPO:-Shybko/beads-web}
+        RELEASE_URL: \${RELEASE_URL}
     container_name: beads-web
     restart: unless-stopped
     ports:
@@ -366,6 +367,7 @@ DATABASE=${DATABASE}
 BEADS_WEB_PORT=${BEADS_WEB_PORT}
 BEADS_WEB_VERSION=${BEADS_WEB_VERSION}
 BEADS_WEB_REPO=${BEADS_WEB_REPO}
+RELEASE_URL=${RELEASE_URL}
 DOLT_HOST=${DOLT_HOST}
 DOLT_PORT=${DOLT_PORT}
 EOF
@@ -390,7 +392,7 @@ build_and_start() {
   echo "  Release URL valid"
 
   cd "$INSTALL_DIR"
-  docker compose build
+  docker compose build --no-cache
   docker compose up -d
   sleep 5
 

--- a/scripts/beads-web/update-remote.sh
+++ b/scripts/beads-web/update-remote.sh
@@ -2,7 +2,8 @@
 # beads-web - Update binary on VPS
 # Downloads the latest binary from GitHub Releases and restarts the container.
 # The release asset can be updated without bumping version via:
-#   gh release upload v0.9.3 beads-web-linux-x64 --repo Shybko/beads-web --clobber
+#   gh release upload <tag> beads-web-linux-x64 --repo Shybko/beads-web --clobber
+# Or if the fork has GitHub Actions, just create a new release from GitHub UI.
 #
 # Usage:
 #   ssh root@vps "bash -s" < scripts/beads-web/update-remote.sh
@@ -47,7 +48,16 @@ fi
 # Read config from existing .env
 BEADS_WEB_VERSION=$(grep '^BEADS_WEB_VERSION=' "$INSTALL_DIR/.env" | cut -d= -f2)
 BEADS_WEB_REPO=$(grep '^BEADS_WEB_REPO=' "$INSTALL_DIR/.env" | cut -d= -f2)
-RELEASE_URL="https://github.com/${BEADS_WEB_REPO}/releases/download/v${BEADS_WEB_VERSION}/beads-web-linux-x64"
+RELEASE_URL=$(grep '^RELEASE_URL=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+
+# Fallback: build URL from version/repo if RELEASE_URL not in .env
+if [[ -z "$RELEASE_URL" ]]; then
+  if [[ "$BEADS_WEB_VERSION" == "latest" ]]; then
+    RELEASE_URL="https://github.com/${BEADS_WEB_REPO}/releases/latest/download/beads-web-linux-x64"
+  else
+    RELEASE_URL="https://github.com/${BEADS_WEB_REPO}/releases/download/v${BEADS_WEB_VERSION}/beads-web-linux-x64"
+  fi
+fi
 
 echo ""
 echo -e "${GREEN}=== beads-web Update ===${NC}"

--- a/scripts/beads-web/update-remote.sh
+++ b/scripts/beads-web/update-remote.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# beads-web - Update binary on VPS
+# Downloads the latest binary from GitHub Releases and restarts the container.
+# The release asset can be updated without bumping version via:
+#   gh release upload v0.9.3 beads-web-linux-x64 --repo Shybko/beads-web --clobber
+#
+# Usage:
+#   ssh root@vps "bash -s" < scripts/beads-web/update-remote.sh
+#   ssh root@vps "bash -s -- --install-dir /opt/beads-web-custom" < scripts/beads-web/update-remote.sh
+#
+# Prerequisites:
+#   - beads-web already installed via setup-remote.sh
+
+set -e
+
+# ============================================
+# Configuration
+# ============================================
+INSTALL_DIR="${INSTALL_DIR:-/opt/beads-web}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================
+# Parse args
+# ============================================
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install-dir) INSTALL_DIR="$2"; shift 2 ;;
+    --) shift ;;
+    *) echo -e "${RED}Unknown argument: $1${NC}"; exit 1 ;;
+  esac
+done
+
+# ============================================
+# Validate
+# ============================================
+if [[ ! -f "$INSTALL_DIR/.env" ]]; then
+  echo -e "${RED}Error: No installation found at $INSTALL_DIR${NC}"
+  echo "Run setup-remote.sh first."
+  exit 1
+fi
+
+# Read config from existing .env
+BEADS_WEB_VERSION=$(grep '^BEADS_WEB_VERSION=' "$INSTALL_DIR/.env" | cut -d= -f2)
+BEADS_WEB_REPO=$(grep '^BEADS_WEB_REPO=' "$INSTALL_DIR/.env" | cut -d= -f2)
+RELEASE_URL="https://github.com/${BEADS_WEB_REPO}/releases/download/v${BEADS_WEB_VERSION}/beads-web-linux-x64"
+
+echo ""
+echo -e "${GREEN}=== beads-web Update ===${NC}"
+echo ""
+echo "  Install dir: $INSTALL_DIR"
+echo "  Repo:        $BEADS_WEB_REPO"
+echo "  Version:     $BEADS_WEB_VERSION"
+echo "  Binary URL:  $RELEASE_URL"
+echo ""
+
+# ============================================
+# 1. Validate release URL
+# ============================================
+echo -e "${YELLOW}[1/3] Checking release URL...${NC}"
+if ! curl -fsSL --head "$RELEASE_URL" >/dev/null 2>&1; then
+  echo -e "${RED}ERROR: Release not found at: $RELEASE_URL${NC}"
+  exit 1
+fi
+echo "  Release URL valid"
+
+# ============================================
+# 2. Rebuild container (re-downloads binary)
+# ============================================
+echo -e "${YELLOW}[2/3] Rebuilding container...${NC}"
+cd "$INSTALL_DIR"
+docker compose build --no-cache
+docker compose up -d
+sleep 5
+
+# ============================================
+# 3. Verify
+# ============================================
+echo -e "${YELLOW}[3/3] Verifying...${NC}"
+if docker compose ps --format '{{.Status}}' | grep -q "Up"; then
+  echo -e "${GREEN}  beads-web running${NC}"
+else
+  echo -e "${RED}ERROR: beads-web failed to start. Check: docker compose logs${NC}"
+  exit 1
+fi
+
+echo ""
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}    beads-web Updated${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo "  Logs:    docker logs beads-web"
+echo "  Status:  cd $INSTALL_DIR && docker compose ps"
+echo ""
+echo -e "${GREEN}========================================${NC}"


### PR DESCRIPTION
## Summary

Docker deployment infrastructure for [beads-web](https://github.com/Shybko/beads-web) - Rust/Next.js Kanban UI for beads issue tracker.

### What's included

- **`scripts/beads-web/setup-remote.sh`** - full install: Docker image, compose, firewall, volumes
- **`scripts/beads-web/update-remote.sh`** - quick update: rebuild image with latest binary, restart
- **`scripts/beads-web/README.md`** - architecture, CLI reference, update workflow, troubleshooting

### Key decisions
- **debian:trixie-slim** base image (binary requires glibc 2.39, bookworm only has 2.36)
- **Port 9090** (beads-ui uses 9080)
- **256M memory limit** (Rust binary vs 512M for Node.js beads-ui)
- **NO_BROWSER=1** env var suppresses browser auto-open in headless/Docker
- **`--repo` flag** for fork support (default: Shybko/beads-web)
- **Single `beads-web` container** serving multiple Dolt databases as projects
- **SQLite volume mount** (`data/kanban-ui/`) persists project configs across rebuilds
- **Update without version bump** via `--clobber` on GitHub Release + `update-remote.sh`

### Deployment flow
```
setup-remote.sh   -> Full install (first time or config changes)
update-remote.sh  -> Quick binary update (code changes, same version)
```

### Update workflow
```
1. Push changes to fork (Shybko/beads-web)
2. Build binary (locally or via GitHub Actions)
3. gh release upload v0.9.3 beads-web-linux-x64 --clobber
4. ssh beads-vps "bash -s" < scripts/beads-web/update-remote.sh
```

## Test plan

- [x] `bash -n` syntax check passes for both scripts
- [x] Full deploy to VPS - container running and healthy
- [x] Frontend loads without errors (v0.9.3 relative URL fix)
- [x] Two projects added via API (`dolt://lets`, `dolt://aff`) - both visible in UI
- [x] IP allowlist works (3 IPs configured, matching beads-ui)
- [x] Idempotent re-run preserves `.env` and rebuilds container
- [x] SQLite DB survives container rebuild (volume mount verified)
- [x] `update-remote.sh` successfully updates binary and restarts
- [x] Projects persist after update (volume mount for `data/kanban-ui/`)

## Related

- [Shybko/beads-web#3](https://github.com/Shybko/beads-web/issues/3) - UI support for adding remote Dolt databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)