### PR TITLE
fix: Reinforce agent OUTPUT response priority over memory writes (round 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ reference/                    # Reference plugins for studying patterns (gitigno
 ## Architecture Decisions
 
 - Agents define WHO and HOW (expertise, behavioral modes, tiered scoring, output format). Commands define WHAT and WHEN (provide content, select agents, pass mode name)
-- Agent frontmatter fields: `name`, `description`, `tools`, `color` (terminal output: red/blue/green/yellow/purple/orange/pink/cyan), optional `model` (default inherits from parent, `opus` for complex analysis), `memory: project` (persistent cross-session learning). All agents use tiered scoring ([BLOCKER]/[SUGGESTION]/[NIT]) and have self-contained Modes and domain-specific `Memory (after output)` sections that explicitly subordinate memory persistence to the primary OUTPUT FORMAT response
+- Agent frontmatter fields: `name`, `description`, `tools`, `color` (terminal output: red/blue/green/yellow/purple/orange/pink/cyan), optional `model` (default inherits from parent, `opus` for complex analysis), `memory: project` (persistent cross-session learning). All agents use tiered scoring ([BLOCKER]/[SUGGESTION]/[NIT]), self-contained Modes, MANDATORY rules in `Output Format` sections, and domain-specific `Memory (after output)` sections that subordinate memory persistence to the primary text response
 - Actor meta-agent loads personalities at runtime via internal skill `actor-fetch-personality`. Command fetches personality content (curl for URLs, Read for files), user confirms via review gate, actor receives it in prompt as `PERSONALITY:` block. Fallback "generalist" identity when no personality provided
 - Agent selection: each command owns its detection/selection logic (different semantics per context). Multi-agent dispatching commands (review, opinion, brainstorm, plan) show selection panel with cost note before launch. Most agents have explicit PLAN mode for plan review.
 - Agents always respond in English. Commands localize output to user's language via LETS Config and Rules.
@@ -79,6 +79,7 @@ Update these files:
 | `commands/install.md` | Essential Skills / Planning Skills tables |
 | `CLAUDE.md` Key Concepts | If adding a new skill |
 | `README.md` | Agent table, feature descriptions |
+| Agent prompts (`agents/*.md`) + Task templates in `commands/{review,plan,opinion}.md` | MANDATORY block + Memory opener: keep wording synced across all 22 occurrences (`grep -n "MANDATORY:" agents/ commands/` to find them) |
 
 ### Command Output Requirements
 

--- a/agents/actor.md
+++ b/agents/actor.md
@@ -57,6 +57,8 @@ Findings are classified by severity using the persona's expertise lens:
 Free-form response in the persona's voice and style, within structured sections.
 Start with: "**{persona name}** says:" (or "**Generalist** says:" if no personality loaded)
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -76,7 +78,7 @@ Evaluate the plan from the persona's perspective. Check completeness in areas th
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific knowledge through the loaded persona's lens for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific knowledge through the loaded persona's lens for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Project conventions relevant to the persona's domain expertise

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -57,6 +57,8 @@ For each finding:
 **Why it matters:** concrete impact (not theoretical)
 **Suggestion:** specific alternative with reasoning
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -76,7 +78,7 @@ Evaluate architecture completeness: are components well-defined? Are interfaces 
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific architecture knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific architecture knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Module boundaries, layering decisions, and coupling patterns

--- a/agents/backend.md
+++ b/agents/backend.md
@@ -59,6 +59,8 @@ For each finding:
 **Impact:** what goes wrong and when
 **Fix:** specific code change or approach
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -78,7 +80,7 @@ Review API design, error handling, and service integration points in the propose
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific backend knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific backend knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Error handling strategy and how this project handles failures

--- a/agents/compliance.md
+++ b/agents/compliance.md
@@ -53,6 +53,8 @@ For each finding:
 **Actual:** what the code does instead
 **Fix:** specific change to comply
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -66,7 +68,7 @@ Answer questions about project rules and established conventions. Reference spec
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific compliance knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific compliance knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Explicit rules from CLAUDE.md and their scope of application

--- a/agents/database.md
+++ b/agents/database.md
@@ -58,6 +58,8 @@ For each finding:
 **Impact:** what breaks and at what scale
 **Fix:** specific schema/query/index change
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -77,7 +79,7 @@ Evaluate schema design, migration strategy, and query patterns in the proposed a
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific database knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific database knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Schema conventions, naming patterns, and column type preferences

--- a/agents/devops.md
+++ b/agents/devops.md
@@ -58,6 +58,8 @@ For each finding:
 **Risk:** what fails and when
 **Fix:** specific configuration change
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -77,7 +79,7 @@ Review deployment impact, CI/CD changes, and infrastructure requirements in the 
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific devops knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific devops knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Container setup, base images, and build pipeline structure

--- a/agents/docs.md
+++ b/agents/docs.md
@@ -65,6 +65,8 @@ For each finding:
 **Impact:** how this misleads or confuses
 **Fix:** specific documentation change
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -81,7 +83,7 @@ Focus on documentation debt. What's undocumented, stale, or missing for onboardi
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific documentation knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific documentation knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Documentation structure and where different doc types live

--- a/agents/explorer.md
+++ b/agents/explorer.md
@@ -60,6 +60,8 @@ Return a structured exploration report:
 ### Gaps
 {what doesn't exist yet and needs to be created}
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Rules
 
 - Never recommend or design - only map
@@ -70,7 +72,7 @@ Return a structured exploration report:
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific codebase knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific codebase knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Directory structure conventions and where different types of code live

--- a/agents/frontend.md
+++ b/agents/frontend.md
@@ -58,6 +58,8 @@ For each finding:
 **User impact:** what the user experiences
 **Fix:** specific change with code example if helpful
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -77,7 +79,7 @@ Assess component architecture, state management, and accessibility in the propos
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific frontend knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific frontend knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Component patterns, state management approach, and data flow conventions

--- a/agents/git-historian.md
+++ b/agents/git-historian.md
@@ -53,6 +53,8 @@ For each finding:
 **Risk:** what might go wrong based on history
 **Recommendation:** proceed, investigate further, or reconsider
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -66,7 +68,7 @@ Answer questions about code evolution, past decisions, change attribution. Use g
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific history knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific history knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Deliberate design decisions confirmed by commit messages or PR context

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -24,21 +24,6 @@ Each teammate handles one task in an isolated worktree.
 - Verify your work. Run tests, check compilation, review your own diff.
 - Communicate blockers early. Don't spin silently.
 
-## Memory (after output)
-
-After completing your work and producing the Output summary, persist project-specific implementation knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the primary output.
-
-Remember:
-- Code style, formatting, and naming conventions in active use
-- Build and test commands that work for this project
-- Common gotchas encountered during implementation
-- Patterns for creating new files (boilerplate, imports, structure)
-
-Do NOT remember:
-- Specific file contents or line numbers (they change)
-- One-off implementation details unlikely to recur
-- Generic coding best practices you already know
-
 ## Constraints
 
 - Stay within your assigned file boundaries - do not touch files outside your task scope
@@ -67,6 +52,23 @@ When complete, provide:
 - List of files created/modified
 - Test results (if applicable)
 - Any concerns or follow-up items for the lead
+
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
+## Memory (after output)
+
+After your text response, persist project-specific implementation knowledge for future sessions. Memory is an addition, not a replacement for your text response.
+
+Remember:
+- Code style, formatting, and naming conventions in active use
+- Build and test commands that work for this project
+- Common gotchas encountered during implementation
+- Patterns for creating new files (boilerplate, imports, structure)
+
+Do NOT remember:
+- Specific file contents or line numbers (they change)
+- One-off implementation details unlikely to recur
+- Generic coding best practices you already know
 
 ## Note
 

--- a/agents/pragmatist.md
+++ b/agents/pragmatist.md
@@ -63,6 +63,8 @@ For each finding:
 **Simpler alternative:** specific approach that would work
 **When to reconsider:** conditions under which the complex approach becomes justified
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -82,7 +84,7 @@ Assess if overall approach is proportional. Flag tasks that could be cut without
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific pragmatism knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific pragmatism knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Complexity budget: where the project chose simple over clever (and vice versa)

--- a/agents/qa.md
+++ b/agents/qa.md
@@ -58,6 +58,8 @@ For each finding:
 **Gap:** what bug would slip through
 **Fix:** specific test to add or modify
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -77,7 +79,7 @@ Evaluate testability, coverage strategy, and edge case handling in the proposed 
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific testing knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific testing knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Test framework, runner, and assertion library in use

--- a/agents/security.md
+++ b/agents/security.md
@@ -54,6 +54,8 @@ For each finding:
 **Attack scenario:** how it could be exploited
 **Fix:** specific remediation with code example if applicable
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ## Modes
 
 ### REVIEW
@@ -73,7 +75,7 @@ Focus on auth flows, data validation, and secrets handling in the proposed archi
 
 ## Memory (after output)
 
-After delivering your OUTPUT FORMAT response, persist project-specific security knowledge for future sessions. Memory is an addition, not a replacement. Never substitute memory writes for the OUTPUT FORMAT response.
+After your text response, persist project-specific security knowledge for future sessions. Memory is an addition, not a replacement for your text response.
 
 Remember:
 - Auth patterns, trust boundaries, and session management approach

--- a/commands/opinion.md
+++ b/commands/opinion.md
@@ -106,7 +106,9 @@ OPTIONS:
 A) {option A description}
 B) {option B description}
 C) {option C description - if applicable}
-CONSTRAINTS: {context, time, legacy, etc.}"
+CONSTRAINTS: {context, time, legacy, etc.}
+
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response."
 )
 ```
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -155,7 +155,9 @@ YOUR FOCUS:
 {specific bullets tailored to this focus area}
 
 Return the structured exploration report as defined in your system prompt.
-Focus ONLY on {focus area} - other explorers cover other areas."
+Focus ONLY on {focus area} - other explorers cover other areas.
+
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response."
 )
 ```
 
@@ -308,7 +310,9 @@ OUTPUT:
 ### Trade-offs
 - Pro: {advantages}
 - Con: {limitations}
-- Risk: {what could go wrong}"
+- Risk: {what could go wrong}
+
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response."
 )
 ```
 
@@ -442,7 +446,9 @@ CHOSEN ARCHITECTURE:
 
 {If actor agent: include PERSONALITY block from actor-fetch-personality skill}
 PERSONALITY:
-{fetched personality content - only for lets:actor, omit for other agents}"
+{fetched personality content - only for lets:actor, omit for other agents}
+
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response."
 )
 ```
 

--- a/commands/review.md
+++ b/commands/review.md
@@ -275,6 +275,8 @@ CHANGED FILES:
 CODE:
 {diff_content, or full file content for --file mode}
 
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response.
+
 ```
 
 ## Step 6: Filter & Aggregate Results
@@ -564,7 +566,9 @@ OUTPUT FORMAT:
 {things the plan should cover but doesn't}
 
 ### Strengths
-{1-2 things done well - keep feedback balanced}"
+{1-2 things done well - keep feedback balanced}
+
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response."
 )
 ```
 
@@ -612,7 +616,9 @@ OUTPUT FORMAT:
 - Missing essentials: {if any}
 
 ### Bottom Line
-{1-2 sentences: ship it or revise it, and why}"
+{1-2 sentences: ship it or revise it, and why}
+
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response."
 )
 ```
 
@@ -657,7 +663,9 @@ OUTPUT FORMAT:
 {risks from your area of expertise}
 
 ### Strengths
-{1-2 things done well}"
+{1-2 things done well}
+
+**MANDATORY:** Always emit the full structured response as text. If you persist to memory, do it AFTER your text response is complete. Never emit only "Memory persisted" or a tool-call summary as your response."
 )
 ```
 


### PR DESCRIPTION
## Summary

Round 2 of `lets-20nye`. PR #43 (round 1) renamed Memory section and added subordination wording, but empirical testing showed agents (architect, qa) still substituted memory-write summaries for structured findings.

## Failure mode confirmed

Agents emitted text like:
- `"Memory persisted. Two new lessons indexed: ..."` + brief path list
- `"Memory updated. Index has 6 entries..."`

Instead of the requested structured `## Plan Review: Architecture / ### Verdict / ### Findings` format.

## Changes

### Agent files (14)
- Add `**MANDATORY:**` block at end of `## Output Format` section (3 imperative directives):
  1. Always emit the full structured response as text
  2. If you persist to memory, do it AFTER your text response is complete
  3. Never emit only "Memory persisted" or a tool-call summary as your response
- Cleaner Memory section opener: `"After your text response, persist project-specific {domain} knowledge for future sessions. Memory is an addition, not a replacement for your text response."` (replaces 3-sentence version with redundant anti-pattern; aligns with new MANDATORY terminology)
- Reorder `implementer.md` to standard section order (Memory after Output)
- Preserve actor.md exception: `"knowledge through the loaded persona's lens"`

### Orchestrator templates (8 templates in 3 files)
- Add identical MANDATORY block at end of each Task prompt body in `commands/{review,plan,opinion}.md`
- Belt+suspenders: agent file + orchestrator prompt both reinforce

### Documentation
- `CLAUDE.md` Architecture Decisions: mention MANDATORY rules, update terminology to "text response"
- `CLAUDE.md` maintenance table: add drift-protection row covering MANDATORY block sync across all 22 occurrences

## Why agent-optimized wording

Discussion led to imperative directive form (Always/If/Never) rather than descriptive ("X is invalid", "happens after"). LLMs comply more strongly with directive verbs and concrete anti-patterns ("Memory persisted") than abstract judgments.

## Scope

- 18 files modified, +81/-36
- Read-only constraints, frontmatter, modes untouched
- No command/skill API changes, no logic changes

## Test plan

- [ ] Run `/lets:review --plan` in a battle-tested project (e.g. android-browser) on a real plan with security/qa-relevant content
- [ ] Confirm architect and qa return full structured findings (not memory-write confirmations)
- [ ] Verify memory writes still occur after text response (no regression)
- [ ] If substitution recurs, escalate by investigating `memory: project` mechanism semantics

Refs lets-20nye.