### PR TITLE
fix: Skill path resolution + brainstorm Review backlog mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ reference/                    # Reference plugins for studying patterns (gitigno
 - SessionStart hook reads `.lets/config.yaml` and injects settings into session context
 - Statusline source in `scripts/lets/statusline.sh`, copied to `.lets/statusline.sh` per-project by `/lets:init`. Project `.claude/settings.json` uses `git rev-parse --show-toplevel` to locate it.
 - User-facing skills: auto-discovered by Claude Code, appear in skill list, trigger on description match. Frontmatter description must NOT use YAML quotes.
-- Internal skills: NOT auto-discovered. Commands reference with "use the X skill" - Claude reads the SKILL.md via Read tool. No accidental triggering, no context cost until needed.
+- Internal skills: NOT auto-discovered. Commands reference with "use the X skill" and read the SKILL.md via Read tool at `` `${CLAUDE_PLUGIN_ROOT}/skills/X/SKILL.md` `` - the env var ensures the path resolves correctly whether plugin is loaded via marketplace install or `--plugin-dir` dev mode (relative `skills/...` paths break in foreign projects). No accidental triggering, no context cost until needed.
 - Commands define WHAT to do and orchestrate the flow. User-facing skills define full reusable flows (steps, user gates) that auto-trigger on natural language. Internal skills define shared procedures read by commands on demand. Commands delegate to skills for shared operations.
 - Gate for new skills: extract only if (a) user-facing with standalone trigger value, or (b) internal logic duplicated in 3+ commands.
 

--- a/commands/ask.md
+++ b/commands/ask.md
@@ -48,7 +48,7 @@ Available experts (map to `lets:*` agents):
 
 **Shorthand mapping:** User can type short names like "security" or "sec" - map to the correct agent subagent_type.
 
-**Actor handling:** If expert is `actor`, the remaining argument should contain a personality source (URL or file path) followed by the question. Example: `/lets:ask actor https://example.com/persona.md "question"`. Use the **actor-fetch-personality** skill (read `skills/actor-fetch-personality/SKILL.md`) to fetch and validate the personality. If no source provided, ask via AskUserQuestion: "Personality source? (URL or file path)". Pass fetched content as `PERSONALITY:` block in the Task prompt (see Step 4).
+**Actor handling:** If expert is `actor`, the remaining argument should contain a personality source (URL or file path) followed by the question. Example: `/lets:ask actor https://example.com/persona.md "question"`. Use the **actor-fetch-personality** skill (read `${CLAUDE_PLUGIN_ROOT}/skills/actor-fetch-personality/SKILL.md`) to fetch and validate the personality. If no source provided, ask via AskUserQuestion: "Personality source? (URL or file path)". Pass fetched content as `PERSONALITY:` block in the Task prompt (see Step 4).
 
 **If no expert specified**, select top 4 most relevant based on conversation context and use **AskUserQuestion**:
 
@@ -121,7 +121,7 @@ Show the agent's response:
 
 ## Step 6: Link Answer to Active Task
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 If multiple tasks found, skip beads comment.
 If active task found:
 

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -141,7 +141,7 @@ AskUserQuestion(
 | explorer | No | Already used in phase 1 |
 | actor | Yes | External perspective via loaded persona (user must provide source) |
 
-**Actor note:** If actor is selected, use the **actor-fetch-personality** skill (read `skills/actor-fetch-personality/SKILL.md`) to fetch personality. Pass `PERSONALITY:` block in the actor's Task prompt only.
+**Actor note:** If actor is selected, use the **actor-fetch-personality** skill (read `${CLAUDE_PLUGIN_ROOT}/skills/actor-fetch-personality/SKILL.md`) to fetch personality. Pass `PERSONALITY:` block in the actor's Task prompt only.
 
 Show selection before launching (no user gate - brainstorm = momentum):
 

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -343,12 +343,11 @@ OUTPUT FORMAT - Project State Profile:
 
 PROJECT ROOT: {project-root from LETS Config}. Do NOT read or search files outside this directory.
 
-MODE: brainstorm
+MODE: brainstorm (review backlog)
 
-Generate ideas and surface gaps from your area of expertise.
+Review the project's BACKLOG of tasks from your area of expertise. Surface gaps in WHAT'S BEING TRACKED: missing themes, priority imbalances, areas with no tasks but clear need from your domain.
 
-You are NOT reviewing code or evaluating a decision. You are looking at a project's
-current state and generating actionable insights about what to build, fix, or improve.
+You are NOT reviewing code, counting duplications, finding stale files, or hunting bugs in source. The PROJECT STATE PROFILE below is your primary source. Use bd commands (bd show, bd comments) for task details. Code reads are allowed only as evidence for a backlog observation ("this critical area has no tasks tracking it"), never as primary investigation.
 
 PROJECT RULES (from CLAUDE.md):
 {CLAUDE.md summary, first 100 lines - architecture decisions and structure}
@@ -357,29 +356,28 @@ PROJECT STATE PROFILE:
 {explorer output from Phase 1}
 
 INSTRUCTIONS:
-- Scan the project from YOUR expertise lens
-- Read files in areas relevant to your domain if needed (you have Read/Grep/Glob)
-- Generate 3-7 ideas: things to build, improve, fix, or investigate
-- Each idea must be specific and actionable (not vague like 'improve testing')
-- Prioritize ideas by impact (high/medium)
-- Flag gaps: areas with no tasks but clear need from your perspective
-- Connect to existing tasks when relevant ('task X could be extended to also cover Y')
-- Be opinionated - rank and recommend, don't just list
+- Anchor on the BACKLOG STATE from the profile above (open/in-progress tasks, recent closures, gaps)
+- Generate 3-7 backlog-level insights from your domain lens: what tasks SHOULD exist but don't? what existing tasks need re-prioritization, scope changes, or to be split/closed?
+- Each insight must be backlog-actionable: not "improve testing" but "backlog has 0 tasks tracking auth flow regressions despite 4 recent auth changes, propose creating one"
+- Prioritize by impact (high/medium)
+- Connect to existing tasks: "task X could be extended to cover Y", "task A and B overlap, suggest merging"
+- If you reference code, frame as backlog evidence ("Pattern X exists in 5 files but no task tracks consolidation"), never as code review
+- Be opinionated: rank and recommend, don't just list
 
 OUTPUT FORMAT:
 
-## {Your Domain} Perspective
+## {Your Domain} Backlog Review
 
-### Top Ideas
-1. **{idea title}** [Impact: high/medium]
-   {2-3 sentences: what, why it matters, rough scope}
-   {connection to existing task if any}
+### Missing from Backlog
+1. **{theme or task that should exist}** [Impact: high/medium]
+   {why this gap matters from your domain}
+   {suggested bd create command or task brief}
 
-### Gaps I See
-- {gap}: {why this matters from your expertise}
+### Existing Tasks Needing Adjustment
+- **{task-id}** ({title}): {what to change: bump priority, expand scope, split, deprioritize, close as obsolete, with reason}
 
-### Quick Wins
-- {small improvement that could be done in one session}"
+### Backlog Themes ({domain} lens)
+{1-2 observations about distribution, gaps, drift from project goals: what the backlog reveals about project priorities}"
 ```
 
 Then enter Heavy Mode Flow (Phase 1).

--- a/commands/check.md
+++ b/commands/check.md
@@ -165,7 +165,7 @@ Classify each finding:
 
 If issues were found, record in beads:
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 If multiple tasks found, skip beads comment.
 If active task found AND issues detected:
 

--- a/commands/commit.md
+++ b/commands/commit.md
@@ -6,6 +6,6 @@ description: Commit changes with proper review and conventional commit message
 
 **This command delegates to the commit skill.**
 
-When invoked via `/lets:commit`, read and follow the commit skill flow in `skills/commit/SKILL.md`.
+When invoked via `/lets:commit`, read and follow the commit skill flow in `${CLAUDE_PLUGIN_ROOT}/skills/commit/SKILL.md`.
 
 The commit skill also triggers implicitly when user says "commit", "закоміть", etc. in any conversation context - in that case the skill loads automatically via description match.

--- a/commands/done.md
+++ b/commands/done.md
@@ -10,7 +10,7 @@ Complete the current task. Document work, create PR or merge locally, close in b
 
 ## Step 1: Active Task Detection
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 If no task found: ask user which task to close.
 
 ### Epic Guard

--- a/commands/end.md
+++ b/commands/end.md
@@ -64,7 +64,7 @@ Cleanup:  /lets:worktree remove {name} (if task completed)
 git status --short
 ```
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 
 ## Step 2: Handle Uncommitted Changes
 

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -11,7 +11,7 @@ Load an implementation plan and execute it using Claude Code's native plan mode.
 
 ## Step 1: Active Task Detection
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 If not on a feature/worktree branch and no in-progress task found - ask user which task to execute.
 
 Verify not on main/master:

--- a/commands/note.md
+++ b/commands/note.md
@@ -22,7 +22,7 @@ Use `/lets:note` when you want to add extra context that doesn't fit those flows
 
 ## Step 1: Active Task Detection
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 If no active task or multiple tasks found - ask user which task to add a note to.
 
 ## Step 2: Review Current State

--- a/commands/opinion.md
+++ b/commands/opinion.md
@@ -38,7 +38,7 @@ Adjust based on decision complexity - add more experts for cross-cutting decisio
 **Guidelines:**
 - `architect` and `pragmatist` always included
 - Table above is a starting point, not a cap - add or remove agents based on context
-- `actor` can replace or supplement any domain agent. If actor is selected, use the **actor-fetch-personality** skill (read `skills/actor-fetch-personality/SKILL.md`) to fetch personality. Pass `PERSONALITY:` block in the actor's Task prompt only.
+- `actor` can replace or supplement any domain agent. If actor is selected, use the **actor-fetch-personality** skill (read `${CLAUDE_PLUGIN_ROOT}/skills/actor-fetch-personality/SKILL.md`) to fetch personality. Pass `PERSONALITY:` block in the actor's Task prompt only.
 - Agents use their own model from frontmatter (opus for critical agents, session model for others)
 
 **Confirmation gate:** If planning to launch more than 10 experts:
@@ -158,7 +158,7 @@ For each agent, summarize their position:
 
 Record the decision in beads for future context recovery:
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 If multiple tasks found, skip beads comment.
 If active task found:
 

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -21,7 +21,7 @@ Wait for answer before proceeding.
 
 ## Step 2: Active Task Context
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 
 If task found:
 ```bash

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -137,7 +137,7 @@ AskUserQuestion(
 
 Resolve task-id now - after checkout the branch name changes to the PR branch.
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 If ambiguous or not found: skip beads logging later.
 
 Store detected task-id for use in `bd comments add` calls throughout the lifecycle.
@@ -786,7 +786,7 @@ If in worktree (`$GIT_DIR` contains `worktrees/`): warn "Already in a worktree -
 Else: `gh pr checkout <PR>` (same stash handling as Step 2.3).
 
 **Detect active task** (before branch switch, same as Step 2.2):
-Use the **detect-task** skill (read `skills/detect-task/SKILL.md`).
+Use the **detect-task** skill (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md`).
 Store detected task_id for beads logging in 6.6.
 
 Check for existing `$PR_DIR/response.json`:

--- a/commands/review.md
+++ b/commands/review.md
@@ -170,7 +170,7 @@ Scan the diff for file patterns:
 | `lets:pragmatist` | Large changes (> 200 lines) | Small changes |
 | `lets:actor` | Explicit user request only | Always (never auto-selected) |
 
-**Actor note:** Actor is never auto-selected. When user explicitly requests it, use the **actor-fetch-personality** skill (read `skills/actor-fetch-personality/SKILL.md`) to fetch personality. Pass `PERSONALITY:` block in the actor's Task prompt only.
+**Actor note:** Actor is never auto-selected. When user explicitly requests it, use the **actor-fetch-personality** skill (read `${CLAUDE_PLUGIN_ROOT}/skills/actor-fetch-personality/SKILL.md`) to fetch personality. Pass `PERSONALITY:` block in the actor's Task prompt only.
 
 ### 4.2.1 File Mode Adjustments
 
@@ -437,7 +437,7 @@ Display full report in console.
 
 ## Step 10: Link Review to Active Task
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 If multiple tasks found via fallback, skip beads comment.
 If active task found:
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -97,7 +97,7 @@ Recent: {last 3 commits}
 
 ## Step 6: Take Task
 
-After task is selected, delegate to the **take-task** skill to claim it and prepare the branch (read `skills/take-task/SKILL.md` and follow its flow).
+After task is selected, delegate to the **take-task** skill to claim it and prepare the branch (read `${CLAUDE_PLUGIN_ROOT}/skills/take-task/SKILL.md` and follow its flow).
 
 The take-task skill handles: setting task to `in_progress`, uncommitted changes check, worktree detection, branch creation/switching, offering worktree option, context recovery, saving session start ref.
 

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -24,7 +24,7 @@ If no changes - inform user and exit.
 
 ### Step 2: Active Task Detection
 
-Use the **detect-task** skill to find the active task (read `skills/detect-task/SKILL.md` and follow its detection flow).
+Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 If multiple tasks found: ask user via AskUserQuestion to pick, or "None".
 If not found: commit without task link.
 


### PR DESCRIPTION
## Summary

Two unrelated bug fixes bundled in one branch (per session decision).

### `lets-6xe7b` — Skill path resolution in foreign projects
Relative `skills/X/SKILL.md` paths in instructional prose broke when the plugin ran in foreign projects (Claude resolved against CWD, fell back to filesystem-wide find for SKILL.md, sometimes loading the wrong skill). Prefix all 18 references in `commands/*.md` and `skills/commit/SKILL.md` with `${CLAUDE_PLUGIN_ROOT}/` so the plugin root resolves correctly in both marketplace install and `--plugin-dir` dev mode.

Documented the convention in `CLAUDE.md` Architecture Decisions.

Commit: `21dc370`

### `lets-9v5kh` — Brainstorm Review backlog mode
AGENT_PROMPT_TEMPLATE for Review backlog invited code-review behavior ("Scan project from expertise lens", "Read files in areas relevant to your domain"). Agents (architect, pragmatist, docs) produced code-review findings (counting duplications, stale files, doc-sync audits) instead of backlog insights (missing themes, priority imbalances, task gaps).

Rewrite the prompt to anchor on PROJECT STATE PROFILE (backlog data) as primary source. Code reads now allowed only as evidence for backlog observations, never as primary investigation. Restructure OUTPUT FORMAT around backlog actions (Missing from Backlog / Existing Tasks Needing Adjustment / Backlog Themes).

Commit: `5573d38`

## Side note: `lets-zsyk3` closed without code

Originally planned to be the third fix on this branch (subagent permission failures in /lets:review). After empirical testing (dispatched `lets:git-historian` on a real ASK task: 9 successful Bash tool calls in 52s, full structured response), it became clear the original symptom was likely conflated with `lets-20nye` memory substitution + a `//Users` typo in user's `.claude/settings.local.json` (user-side, already fixed). Closed with detailed reason. No code changes needed.

## Scope

- 15 files for `lets-6xe7b` (14 `commands/*.md` + `skills/commit/SKILL.md` + `CLAUDE.md`)
- 1 file for `lets-9v5kh` (`commands/brainstorm.md`)
- Total: 16 files, +38/-40

## Test plan

### `lets-6xe7b` skill paths
- [ ] Run `/lets:commit` (or any command using detect-task) in a non-lets-workflow project (e.g., `vps-nginx-proxy`) — confirm `${CLAUDE_PLUGIN_ROOT}` resolves and `detect-task` skill loads on first attempt without filesystem `find` fallback
- [ ] Verify the same in `--plugin-dir` dev mode (current `lets-claude` alias)

### `lets-9v5kh` brainstorm backlog
- [ ] Run `/lets:brainstorm` -> Review backlog on a project with substantial backlog
- [ ] Confirm agents return backlog-level insights (missing tasks, priority shifts, themes), not code-review findings
- [ ] Verify "Backlog Themes" section appears in agent output

Refs lets-6xe7b, lets-9v5kh.