### PR TITLE
fix: Add deferred-tool callout to commands and skills

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,3 +111,4 @@ Every lets:* command MUST end with branded LETS box:
 - [ ] Updates `/lets:install` Essential Skills / Planning Skills tables
 - [ ] Follows session flow (start -> work -> commit -> done -> end)
 - [ ] Description is clear and actionable
+- [ ] **If file invokes any deferred tool** (`AskUserQuestion`, `EnterPlanMode`, `WebFetch`, etc.), include the `> **IMPORTANT:**` deferred-tool callout right after the file's brief description, before the first `## Step` (or first major section). Wording: see existing commands/skills for the standard block (search for `IMPORTANT:** If the spec below`)

--- a/commands/ask.md
+++ b/commands/ask.md
@@ -7,6 +7,8 @@ argument-hint: "[expert] [question]"
 
 Quick consultation with a single expert agent. Like pinging a colleague on Slack.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Usage
 
 ```bash

--- a/commands/brainstorm.md
+++ b/commands/brainstorm.md
@@ -9,6 +9,8 @@ Interactive ideation with 4 modes. Heavy modes launch explorer + parallel agents
 
 **This command helps with WHAT to build. For HOW to build it, use `/lets:plan`.**
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Step 0: Choose Mode
 
 If argument provided AND it's clearly an idea/topic (not an epic name), go directly to Explore idea mode.

--- a/commands/done.md
+++ b/commands/done.md
@@ -8,6 +8,8 @@ Complete the current task. Document work, create PR or merge locally, close in b
 
 **This is NOT session end.** Use `/lets:end` to end a session. `/lets:done` finishes a TASK.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Step 1: Active Task Detection
 
 Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).

--- a/commands/end.md
+++ b/commands/end.md
@@ -9,6 +9,8 @@ End a work session properly. Save context for next session.
 
 **This is NOT task completion.** Use `/lets:done` to finish a task. `/lets:end` ends a SESSION.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Fast Mode
 
 If `--fast` argument provided, skip to Fast Close below and do NOT run Steps 1-7.

--- a/commands/execute.md
+++ b/commands/execute.md
@@ -9,6 +9,8 @@ Load an implementation plan and execute it using Claude Code's native plan mode.
 
 **Plan is a roadmap, not a script.** Read real files before every change. Adapt to current context.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Step 1: Active Task Detection
 
 Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).

--- a/commands/init.md
+++ b/commands/init.md
@@ -6,6 +6,8 @@ description: Initialize LETS in current project - creates .lets/ structure, conf
 
 Per-project LETS setup. Creates `.lets/` structure, config, statusline, and initializes beads.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Step 1: Check Current State
 
 ```bash

--- a/commands/note.md
+++ b/commands/note.md
@@ -13,6 +13,8 @@ Add a note to the active beads task. For mid-work documentation - progress updat
 
 Use `/lets:note` when you want to add extra context that doesn't fit those flows.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## When to Use
 
 - Research findings: "Investigated X, found Y"

--- a/commands/opinion.md
+++ b/commands/opinion.md
@@ -9,6 +9,8 @@ Analyze technical decisions by launching expert agents in parallel. Each agent p
 
 **DO NOT ask the user which option to choose.** Analyze and recommend.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Step 1: Frame the Problem
 
 ```

--- a/commands/plan.md
+++ b/commands/plan.md
@@ -9,6 +9,8 @@ Turn a task or idea into a detailed implementation plan. Clarifies scope, explor
 
 **HARD-GATE: This command produces a plan, NOT code. No files are modified except .lets/plans/.**
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Step 1: Capture the Goal
 
 **If argument provided:** use it as the feature goal.

--- a/commands/pr.md
+++ b/commands/pr.md
@@ -9,6 +9,8 @@ Full GitHub PR review lifecycle: analyze code, discuss findings with user, post 
 
 **Requires:** `gh` CLI installed and authenticated.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Usage
 
 ```bash

--- a/commands/review.md
+++ b/commands/review.md
@@ -10,6 +10,8 @@ Comprehensive code review with dynamic agent selection based on change types. Up
 - Local changes (saves to file)
 - Implementation plans (reviews `.lets/plans/` files)
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Usage
 
 ```bash

--- a/commands/status.md
+++ b/commands/status.md
@@ -6,6 +6,8 @@ description: Quick session status - what's done and what's planned (short summar
 
 Show task tracker state. Supports focused views via argument or interactive selection.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Step 1: Determine View
 
 **If argument is provided** (e.g., `/lets:status overview`), use that view directly.

--- a/commands/team.md
+++ b/commands/team.md
@@ -9,6 +9,8 @@ Spawn teammates in isolated worktrees for parallel implementation. Each teammate
 
 **This is for parallel implementation of independent tasks.** For analysis (review, opinion, plan) - use their dedicated commands.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Step 1: Determine Subcommand
 
 **If argument provided** (e.g., `/lets:team run`), parse it:

--- a/commands/worktree.md
+++ b/commands/worktree.md
@@ -8,6 +8,8 @@ Create and manage interactive worktrees for parallel work sessions. Each worktre
 
 **This is for interactive parallel sessions.** Agent worktrees (isolation: worktree) use native Claude Code behavior and don't need this command.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Step 1: Determine Subcommand
 
 **If argument provided** (e.g., `/lets:worktree create auth-feature`), parse it:

--- a/skills/actor-fetch-personality/SKILL.md
+++ b/skills/actor-fetch-personality/SKILL.md
@@ -7,6 +7,8 @@ description: Internal skill for commands. Fetch and validate personality from UR
 
 Internal skill used by commands that dispatch the Actor agent. Handles personality source detection, fetching, validation, and prompt formatting.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Flow
 
 ### Step 1: Detect Source Type

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -7,6 +7,8 @@ description: This skill should be used when committing code changes - "commit", 
 
 Standardized commit flow that enforces conventional format, beads task linking, and user approval.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Why This Exists
 
 Direct `git commit` skips task linking, format enforcement, and approval gates. This skill ensures every commit follows conventions whether invoked via `/lets:commit` or implicit "закоміть".

--- a/skills/detect-task/SKILL.md
+++ b/skills/detect-task/SKILL.md
@@ -7,6 +7,8 @@ description: Internal skill for commands. Detect active beads task from git bran
 
 Parse current git branch to find the active beads task ID. Used by commands that need to know which task is in progress.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Why This Exists
 
 10+ commands need to detect the active task from branch name. This skill centralizes the logic so branch format changes are updated in one place.

--- a/skills/take-task/SKILL.md
+++ b/skills/take-task/SKILL.md
@@ -7,6 +7,8 @@ description: This skill should be used when claiming a task to work on - "take t
 
 Claim a beads task and prepare the working environment.
 
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+
 ## Why This Exists
 
 Multiple flows need "claim task + prepare branch": /lets:start, mid-session task switch, direct "візьми таск X". Centralizing ensures consistent branch naming, worktree handling, and session ref saving.


### PR DESCRIPTION
## Problem

When a command or skill spec invokes a deferred tool (`AskUserQuestion`, `EnterPlanMode`, `WebFetch`, etc.), Claude sometimes shortcuts the call and substitutes a default answer because loading via `ToolSearch` feels like overhead.

**Observed:** /lets:status invocation without arg. Spec has explicit `AskUserQuestion(...)` picker block with 5 view options. Claude jumped straight to "Overview" view without asking, taking the user's choice away. User called this out: "я хочу щоб це завжди було".

## Audit

| Stat | Value |
|---|---|
| Files using AskUserQuestion | 18 (14 commands + 4 skills) |
| Total mentions | ~94 |
| Distinct decision points | ~50 |

**Top offenders:**
- `commands/done.md` (19 mentions): branch handling, push gate, what's next
- `commands/pr.md` (16 mentions): PR review lifecycle gates
- `commands/plan.md` (9): clarifying questions, approach selection
- `commands/end.md` (8): session triage decisions

## Solution choices considered

| Option | Pros | Cons |
|---|---|---|
| Edit each AskUserQuestion invocation | most explicit | ~94 places, high maintenance |
| Single global rule in `hooks/rules-context.md` | one place | lowest locality, easy to ignore |
| **One IMPORTANT callout per file** ✅ | per-file context, 18 changes | identical wording duplicated |

Chose the third: one IMPORTANT callout right after each file's brief description, before the first `## Step` (or first major section). Locality wins over deduplication; 18 << 94.

## Wording

```
> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
```

Generic to cover `AskUserQuestion` and any other deferred tool a file may use. Does NOT hardcode `ToolSearch(query="select:ToolName")` syntax — agents already know the loading mechanism, and hardcoding creates coupling to current API.

## Files

- 14 commands: `ask`, `brainstorm`, `done`, `end`, `execute`, `init`, `note`, `opinion`, `plan`, `pr`, `review`, `status`, `team`, `worktree`
- 4 skills: `actor-fetch-personality`, `commit`, `detect-task`, `take-task`
- `CLAUDE.md`: new bullet in "Command Checklist" reminding future authors to include the callout in new files using deferred tools

## Scope

19 files modified, +37/-0. Pure additions. No logic changes, no spec wording changes (besides the callout addition).

## Test plan

- [ ] Run `/lets:status` without argument: picker MUST appear via AskUserQuestion (not jump to overview)
- [ ] Run `/lets:brainstorm` without argument: mode picker MUST appear
- [ ] Run `/lets:opinion` with >10 experts: confirmation gate MUST appear
- [ ] Run `/lets:done`: branch-handling AskUserQuestion MUST appear (not auto-decide)
- [ ] Verify across at least 2 sessions to ensure callout is read at command-load time

Refs lets-c4jpw.