### PR TITLE
refactor: Unify analyst agent tools with Bash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ reference/                    # Reference plugins for studying patterns (gitigno
 
 ## Architecture Decisions
 
+- **Audience for plugin source.** Everything in `commands/`, `skills/`, `agents/`, `hooks/rules-context.md` is read by Claude (orchestrator and subagents) - never by humans. Write for the model: direct, structured, parseable. No rhetorical flourishes, no human-onboarding tone. Use markers (`MANDATORY`, `NEVER`, `IMPORTANT`) where the model needs to lock onto a constraint. Tables and bullet lists beat prose. Examples are templates the model imitates - keep them precise. Human-facing docs live in `README.md` and `CLAUDE.md` (this file).
 - Agents define WHO and HOW (expertise, behavioral modes, tiered scoring, output format). Commands define WHAT and WHEN (provide content, select agents, pass mode name)
 - Agent frontmatter fields: `name`, `description`, `tools`, `color` (terminal output: red/blue/green/yellow/purple/orange/pink/cyan), optional `model` (default inherits from parent, `opus` for complex analysis). All agents use tiered scoring ([BLOCKER]/[SUGGESTION]/[NIT]), self-contained Modes, and Output Format sections.
 - Agent memory (`memory: project` frontmatter) is **currently disabled** across all agents as a workaround for upstream Claude Code issue [#55648](https://github.com/anthropics/claude-code/issues/55648). Subagents writing memory skip the assigned task and return only a memory-write confirmation. Disabled via [PR #47](https://github.com/restarter/lets-workflow/pull/47). Tracked via bd tasks `lets-erx1c` (this disable) and `lets-rqwdg` (restore memory when Anthropic fixes the bug).
@@ -36,9 +37,9 @@ reference/                    # Reference plugins for studying patterns (gitigno
 - `/lets:pr` orchestrates `/lets:review` (delegates analysis) and handles GitHub posting, follow-up, respond, and approval directly via gh CLI
 - `/lets:execute` uses EnterPlanMode for native plan mode execution with user approval gates. No subagents.
 - `/lets:check` reviews inline (no subagent) for speed
-- All agents are read-only (Read, Grep, Glob, optionally Bash). No Edit/Write. Exception: `agents/implementer.md` has Edit/Write/Bash for `/lets:team` parallel implementation in isolated worktrees.
+- All analyst agents are read-only with uniform tools: `Read, Grep, Glob, Bash`. No `Edit/Write`. Exception: `agents/implementer.md` adds `Edit/Write` for `/lets:team` parallel implementation in isolated worktrees.
 - `/lets:team` uses Agent Teams (TeamCreate, Agent with isolation: worktree) for parallel implementation. All other commands use subagents for analysis.
-- Agents with Bash have prompt-level read-only constraints (`## Constraints` section in agent `.md` files). `hooks/validate-readonly.sh.old` exists as a PreToolUse hook prototype (not yet registered - agent frontmatter hooks silently ignored)
+- All analyst agents have prompt-level read-only Bash constraints in their `## Constraints` section (identical 1-line allowlist across all 13). `hooks/validate-readonly.sh.old` exists as a PreToolUse hook prototype (not yet registered - agent frontmatter hooks silently ignored)
 - Interactive worktrees managed via `/lets:worktree` command. Hook prototypes `hooks/worktree-setup.sh.old` and `hooks/worktree-cleanup.sh.old` (deferred - caused agent auto-cleanup issues)
 - Worktrees stored in `.worktrees/` at project root - `.lets/` symlinked for interactive sessions
 - SessionStart hook injects rules from `hooks/rules-context.md`
@@ -70,7 +71,7 @@ This includes hook debug logs, temp files, and any runtime artifacts.
 
 - beads plugin (task tracking)
 
-## When Adding/Modifying Commands or Skills
+## When Adding/Modifying Commands, Skills, or Agents
 
 Update these files:
 
@@ -80,6 +81,7 @@ Update these files:
 | `commands/install.md` | Essential Skills / Planning Skills tables |
 | `CLAUDE.md` Key Concepts | If adding a new skill |
 | `README.md` | Agent table, feature descriptions |
+| All `agents/*.md` `## Constraints` sections | If changing the read-only Bash allowlist or constraint wording, sync the identical 1-line text across all 13 analyst agents (verify with `grep -h "You are read-only" agents/*.md \| sort -u` returning exactly one line) |
 
 ### Command Output Requirements
 

--- a/agents/actor.md
+++ b/agents/actor.md
@@ -1,7 +1,7 @@
 ---
 name: actor
 description: Meta-agent that adopts external personalities and adapts them to LETS modes. Loads identity from personality text provided in prompt, then operates as that persona with LETS structured output.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 model: opus
 color: purple
 ---
@@ -72,3 +72,7 @@ Generate ideas through the persona's lens. Leverage their domain strengths and u
 
 ### PLAN
 Evaluate the plan from the persona's perspective. Check completeness in areas the persona cares about.
+
+## Constraints
+
+- You are read-only. Use Bash only for: git log/blame/show/diff, ls, find, wc, cat, head, tail

--- a/agents/architect.md
+++ b/agents/architect.md
@@ -1,7 +1,7 @@
 ---
 name: architect
 description: System design expert for architecture reviews, pattern analysis, SOLID principles evaluation, and coupling/abstraction assessments. Use when reviewing structural changes, evaluating design decisions, or analyzing system architecture.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 model: opus
 color: yellow
 ---
@@ -72,3 +72,7 @@ Focus on structural opportunities. Where could the system be simplified, better 
 
 ### PLAN
 Evaluate architecture completeness: are components well-defined? Are interfaces clear? Is task decomposition aligned with module boundaries?
+
+## Constraints
+
+- You are read-only. Use Bash only for: git log/blame/show/diff, ls, find, wc, cat, head, tail

--- a/agents/compliance.md
+++ b/agents/compliance.md
@@ -1,7 +1,7 @@
 ---
 name: compliance
 description: Project standards expert for CLAUDE.md rules compliance, coding conventions adherence, project-specific patterns verification, and style guide enforcement. Use when checking if code follows project rules and established conventions.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 color: purple
 ---
 
@@ -62,3 +62,7 @@ Assess which option best aligns with project conventions and documented rules. Q
 
 ### ASK
 Answer questions about project rules and established conventions. Reference specific rules from CLAUDE.md.
+
+## Constraints
+
+- You are read-only. Use Bash only for: git log/blame/show/diff, ls, find, wc, cat, head, tail

--- a/agents/docs.md
+++ b/agents/docs.md
@@ -1,7 +1,7 @@
 ---
 name: docs
 description: Documentation expert for API docs review, README assessment, inline documentation analysis, and changelog evaluation. Use when reviewing documentation quality, checking docs-code sync, or evaluating developer onboarding materials.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 color: green
 ---
 
@@ -77,3 +77,7 @@ Answer about documentation structure, conventions, doc-code synchronization.
 
 ### BRAINSTORM
 Focus on documentation debt. What's undocumented, stale, or missing for onboarding?
+
+## Constraints
+
+- You are read-only. Use Bash only for: git log/blame/show/diff, ls, find, wc, cat, head, tail

--- a/agents/frontend.md
+++ b/agents/frontend.md
@@ -1,7 +1,7 @@
 ---
 name: frontend
 description: Frontend development expert for UI component review, state management analysis, accessibility assessment, and bundle optimization. Use when reviewing React, Vue, TypeScript, CSS, or any client-side code.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 color: pink
 ---
 
@@ -73,3 +73,7 @@ Focus on UX gaps, component reuse opportunities, and accessibility. What fronten
 
 ### PLAN
 Assess component architecture, state management, and accessibility in the proposed design.
+
+## Constraints
+
+- You are read-only. Use Bash only for: git log/blame/show/diff, ls, find, wc, cat, head, tail

--- a/agents/implementer.md
+++ b/agents/implementer.md
@@ -2,7 +2,7 @@
 name: implementer
 description: Full-stack implementation specialist for isolated worktree work. Follows existing codebase patterns, implements a single task independently with tests. Use for /lets:team parallel implementation.
 tools: Read, Grep, Glob, Bash, Edit, Write
-model: sonnet
+model: opus
 color: green
 ---
 

--- a/agents/pragmatist.md
+++ b/agents/pragmatist.md
@@ -1,7 +1,7 @@
 ---
 name: pragmatist
 description: Pragmatic ROI analyst for overengineering detection, effort-vs-value assessment, scope creep identification, and "good enough" evaluation. Use when reviewing large changes, evaluating if a solution is proportional to the problem, or assessing business impact.
-tools: Read, Grep, Glob
+tools: Read, Grep, Glob, Bash
 color: orange
 ---
 
@@ -78,3 +78,7 @@ Focus on ROI. Which ideas deliver the most value for least effort? Flag prematur
 
 ### PLAN
 Assess if overall approach is proportional. Flag tasks that could be cut without losing core value. Are there simpler alternatives for any task?
+
+## Constraints
+
+- You are read-only. Use Bash only for: git log/blame/show/diff, ls, find, wc, cat, head, tail


### PR DESCRIPTION
## Summary
- Add `Bash` to 6 analyst agents that lacked it (actor, architect, compliance, docs, frontend, pragmatist). All 13 analysts now share `Read, Grep, Glob, Bash`.
- Closes accidental asymmetry from the initial plugin commit. Also a correctness fix: commands like `/lets:review` and `/lets:brainstorm` instruct agents to run `bd` commands - the 6 without Bash could not honor those.
- Each newly-Bash agent gets the same 1-line read-only `## Constraints` section the existing 7 had (verbatim copy).
- `implementer`: `model: sonnet -> opus` (deliberate, tracked in `lets-dvgft` P1).
- `CLAUDE.md`: new **Audience for plugin source** rule formalizing the model-targeted-writing pattern from PR #43/44/46.
- `CLAUDE.md`: rename "When Adding/Modifying" section to include Agents, add row for keeping `## Constraints` text uniform across 13 files.

## Background
The branch initially attempted a larger refactor (Write tool + per-agent scratch storage in `.lets/temp/<agent>/` + `## Scratch Files` reporting block) - 197 lines. `/lets:review` surfaced 6 BLOCKERs, including risk of recreating PR #47's failure mode (subagents skip primary task to do side-effect writes). Empirical test with biased prompt confirmed the failure. Reverted to this minimal 32-line scope. Removing Write from analysts structurally eliminates the PR #47-shape trigger.

## Test plan
- [x] `/lets:review --local` (4 agents) - 0 BLOCKERS post-fix
- [x] Fair-test dispatch (organic review-shaped prompt) - agent did full analysis without scratch
- [x] \`grep -h "You are read-only" agents/*.md | sort -u\` returns exactly one line (Constraints uniformity)

Task: lets-72v34

🤖 Generated with [Claude Code](https://claude.com/claude-code)