### PR TITLE
feat: Capture Claude session ID in /lets:end and /lets:done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 ### Added
+- `/lets:end` and `/lets:done` capture Claude Code session UUID into beads comments and session summaries for transcript traceability. Session summary now includes `### Claude Session` block with resolved transcript path
 - Skill architecture (`skills/` directory) with two skill types: user-facing (auto-triggered) and internal (read by commands)
 - 4 skills: `commit`, `create-task`, `take-task` (user-facing), `detect-task` (internal)
 - Auto-triggered Skills table in `hooks/rules-context.md` and `commands/install.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ reference/                    # Reference plugins for studying patterns (gitigno
 ## Architecture Decisions
 
 - **Audience for plugin source.** Everything in `commands/`, `skills/`, `agents/`, `hooks/rules-context.md` is read by Claude (orchestrator and subagents) - never by humans. Write for the model: direct, structured, parseable. No rhetorical flourishes, no human-onboarding tone. Use markers (`MANDATORY`, `NEVER`, `IMPORTANT`) where the model needs to lock onto a constraint. Tables and bullet lists beat prose. Examples are templates the model imitates - keep them precise. Human-facing docs live in `README.md` and `CLAUDE.md` (this file).
+- **Claude Code template variables in command/skill markdown.** `${CLAUDE_PLUGIN_ROOT}` (plugin install path) and `${CLAUDE_SESSION_ID}` (session UUID, available since Claude Code v2.1.9) are substituted by Claude Code before the model reads the markdown - immune to context compaction (substitution happens at command/skill load time, not at session start). `${CLAUDE_SESSION_ID}` is documented for skill prompt text; empirically verified to work in command markdown too. Used by `/lets:end` and `/lets:done` to anchor session identity in beads comments and session summaries for transcript traceability. `${CLAUDE_PROJECT_DIR}` is NOT substituted - use `git rev-parse --show-toplevel` instead.
 - Agents define WHO and HOW (expertise, behavioral modes, tiered scoring, output format). Commands define WHAT and WHEN (provide content, select agents, pass mode name)
 - Agent frontmatter fields: `name`, `description`, `tools`, `color` (terminal output: red/blue/green/yellow/purple/orange/pink/cyan), optional `model` (default inherits from parent, `opus` for complex analysis). All agents use tiered scoring ([BLOCKER]/[SUGGESTION]/[NIT]), self-contained Modes, and Output Format sections.
 - Agent memory (`memory: project` frontmatter) is **currently disabled** across all agents as a workaround for upstream Claude Code issue [#55648](https://github.com/anthropics/claude-code/issues/55648). Subagents writing memory skip the assigned task and return only a memory-write confirmation. Disabled via [PR #47](https://github.com/restarter/lets-workflow/pull/47). Tracked via bd tasks `lets-erx1c` (this disable) and `lets-rqwdg` (restore memory when Anthropic fixes the bug).
@@ -82,6 +83,7 @@ Update these files:
 | `CLAUDE.md` Key Concepts | If adding a new skill |
 | `README.md` | Agent table, feature descriptions |
 | All `agents/*.md` `## Constraints` sections | If changing the read-only Bash allowlist or constraint wording, sync the identical 1-line text across all 13 analyst agents (verify with `grep -h "You are read-only" agents/*.md \| sort -u` returning exactly one line) |
+| `commands/end.md` + `commands/done.md` `${CLAUDE_SESSION_ID}` references | If changing the session-id capture wording, sync across all occurrences (Step 3 progress comment + Step 5 summary block in `end.md`, Step 6 completion comment in `done.md`). Verify with `grep -n "CLAUDE_SESSION_ID" commands/` |
 
 ### Command Output Requirements
 

--- a/commands/done.md
+++ b/commands/done.md
@@ -173,6 +173,8 @@ Add completion comment to the task:
 ```bash
 bd comments add <task-id> "## Completed {YYYY-MM-DD}
 
+Claude session: ${CLAUDE_SESSION_ID}
+
 ### Commits
 {git log main..HEAD --oneline}
 

--- a/commands/end.md
+++ b/commands/end.md
@@ -116,6 +116,8 @@ Add progress comment:
 ```bash
 bd comments add <task-id> "## Session progress {YYYY-MM-DD}
 
+Claude session: ${CLAUDE_SESSION_ID}
+
 ### Commits this session
 {git log from start-ref}
 
@@ -163,14 +165,23 @@ BRANCH=$(git branch --show-current)
 BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
 mkdir -p "$ROOT/.lets/sessions"
 SUMMARY_FILE="$ROOT/.lets/sessions/$(date +%Y-%m-%d-%H%M)-${BRANCH_SLUG}.md"
+
+# Resolve actual transcript path (Claude Code stores it as <session-id>.jsonl
+# under a project-slug subdirectory at depth 2; find avoids guessing the slug algorithm)
+TRANSCRIPT_PATH=$(find "$HOME/.claude/projects" -maxdepth 2 -name "${CLAUDE_SESSION_ID}.jsonl" 2>/dev/null | head -1)
+TRANSCRIPT_PATH=${TRANSCRIPT_PATH:-"(not found)"}
 ```
 
-Write summary to `$SUMMARY_FILE`.
+Write summary to `$SUMMARY_FILE` using `$TRANSCRIPT_PATH` in the template below.
 
 **Summary template:**
 
 ```markdown
 ## Session Summary {YYYY-MM-DD HH:MM}
+
+### Claude Session
+- ID: `${CLAUDE_SESSION_ID}`
+- Transcript: `$TRANSCRIPT_PATH`
 
 ### Done
 - {what was completed}


### PR DESCRIPTION
## Summary

Records Claude Code session UUID into beads comments and session summary files for transcript traceability. Each Claude conversation has a unique UUID stored at `~/.claude/projects/<project-slug>/<UUID>.jsonl` - capturing this means user can later find which Claude session made which decision/change.

## Mechanism

Uses `${CLAUDE_SESSION_ID}` template substitution (Claude Code v2.1.9+). Substitution happens at command/skill load time, so it's **immune to context compaction** - works even after 1M tokens of conversation.

Officially documented for skill prompt text. Empirically verified to work in command markdown too (PoC done in this session via test skill + test command).

## Changes

- `/lets:end` Step 3: progress comment includes `Claude session: <id>` line
- `/lets:end` Step 5: summary file gets `### Claude Session` block with ID + transcript path
- `/lets:done` Step 6: completion comment includes session ID
- Transcript path resolved at runtime via `find "$HOME/.claude/projects" -maxdepth 2 -name "<id>.jsonl"` (avoids guessing project-slug algorithm)
- Bash fallback `${TRANSCRIPT_PATH:-"(not found)"}` for edge cases
- `CLAUDE.md` Architecture Decisions documents the template variable mechanism
- `CLAUDE.md` maintenance table adds row for new cross-file invariant
- `CHANGELOG.md` entry under `[Unreleased]` -> Added

## Review process

Iterated through `/lets:review --local`:
- Round 1 BLOCKERs: format inconsistency (`Claude session: <id>` vs `[session <id>]`), missing CLAUDE.md docs, undocumented mechanism
- Applied 6 fixes: dropped close-reason annotation, added Architecture Decisions bullet, added maintenance table row, simplified prose, added -maxdepth 2, CHANGELOG entry
- Net: 4 files, 17 insertions, 1 deletion

## Test plan

- [x] PoC verified `${CLAUDE_SESSION_ID}` substitution works in skills AND commands
- [x] `find -maxdepth 2` resolves real transcript path on this system
- [x] `grep -n CLAUDE_SESSION_ID commands/` returns 4 expected locations
- [ ] Manual test of `/lets:end` after merge: verify summary file has `### Claude Session` block + beads comment has session line
- [ ] Manual test of `/lets:done` after merge: verify completion comment has session line

Task: lets-jkjbq

🤖 Generated with [Claude Code](https://claude.com/claude-code)