### PR TITLE
Scripts ops cleanup: beads-web port 3008 + deprecation + dolt backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Skill architecture (`skills/` directory) with two skill types: user-facing (auto-triggered) and internal (read by commands)
 - 4 skills: `commit`, `create-task`, `take-task` (user-facing), `detect-task` (internal)
 - Auto-triggered Skills table in `hooks/rules-context.md` and `commands/install.md`
-- beads-ui Docker web dashboard (`scripts/beads-ui/`) with deployment script
+- beads-web Docker kanban board (`scripts/beads-web/`) - Rust binary (Shybko/beads-web fork v0.11.0), default port 3008
+- `scripts/dolt/backup-remote.sh` for ad-hoc Dolt server snapshots before risky operations
 - Branch return prompt after worktree creation
 - Actor meta-agent (`agents/actor.md`) for dynamic personality loading from URL or local file
 - `actor-fetch-personality` internal skill for personality fetching via curl/Read
@@ -15,6 +16,9 @@
 
 ### Changed
 - All 13 agent prompts upgraded to v2: tiered scoring ([BLOCKER]/[SUGGESTION]/[NIT]), self-contained behavioral modes, color assignments
+- Moved `scripts/beads-ui/` and legacy `scripts/beads/setup-beads-remote.sh` to `scripts/deprecated/`; superseded by `scripts/beads-web/` (Rust kanban board) and Direct SQL mode respectively
+- `scripts/beads-web/setup-remote.sh`: default port 9090 → 3008 (avoids Prometheus collision; matches upstream binary's native default), Dockerfile heredoc fixed (was unintentionally host-shell-substituted)
+- `scripts/dolt/README.md`: replaced broken cron-based backup snippet (tarred only `dolt-home/`) with ad-hoc `backup-remote.sh` script + 2-layer model (VPS-snap + application-aware)
 - `/lets:brainstorm` redesigned with 4 modes: review backlog, explore idea, quick brainstorm, cleanup
 - Commands thinned - shared logic extracted to skills (`commit.md` 208->11 lines, `start.md` -120 lines)
 - CLAUDE.md architecture decisions updated: agents define WHO+HOW, commands define WHAT+WHEN

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,9 @@ agents/                       # 14 expert agents (architect, security, qa, actor
 skills/                       # Reusable skills (user-facing auto-triggered + internal referenced by commands)
 hooks/                        # SessionStart + PreCompact hooks, workflow rules, config template
 scripts/lets/                 # Statusline + init script (copied/run per-project by /lets:init)
+scripts/dolt/                 # Dolt SQL server VPS deployment + ad-hoc backup
+scripts/beads-web/            # beads-web (Rust kanban board) VPS deployment
+scripts/deprecated/           # Retired scripts kept for cleanup runbooks - not for new installs
 docs/                         # Plans, knowledge base, reference docs, comment exports
 reference/                    # Reference plugins for studying patterns (gitignored)
 ```

--- a/docs/comments/general/dolt-remote-setup.md
+++ b/docs/comments/general/dolt-remote-setup.md
@@ -77,11 +77,13 @@ The project repo (not beads repo) should have these tracked files:
 
 ## Onboarding New Developer
 
-After cloning the project:
+After cloning the project (legacy push/pull mode, now archived):
 
 ```bash
-scripts/beads/setup-beads-remote.sh
+scripts/deprecated/beads/setup-beads-remote.sh
 ```
+
+> **Note:** Direct SQL mode (recommended) skips this script entirely. See `scripts/dolt/README.md` for current setup.
 
 That's it. The script handles everything:
 1. Inits dolt database + beads schema (dolt init, dolt sql-server, bd init)

--- a/scripts/beads-web/README.md
+++ b/scripts/beads-web/README.md
@@ -111,6 +111,32 @@ ssh root@vps "bash -s -- \
 
 The setup script is idempotent - it regenerates config and rebuilds the container.
 
+> **SQLite migrations:** the binary auto-applies pending migrations to `data/kanban-ui/settings.db` on first start (logs `Applied migration vN`). Migrations are additive (`CREATE TABLE IF NOT EXISTS`), so existing projects/tags/cache survive across versions. No manual action required.
+
+### Combined version + port upgrade
+
+When you need both a new binary AND a new port, do it in two phases for safer rollback:
+
+1. **Phase 1 - upgrade binary, keep current port.** Run `update-remote.sh` (or `setup-remote.sh` with the same `--port`). Verify the new version works on the existing port before changing anything else.
+2. **Phase 2 - migrate port.** Follow [Migrating Port](#migrating-port) below. If the binary has issues, you'll hit them in phase 1 with the firewall still intact.
+
+> **Recommended:** run [scripts/dolt/backup-remote.sh](../dolt/README.md#backups) before any phase 1 or phase 2 to take a point-in-time snapshot of the Dolt server. Cheap insurance for risky operations.
+
+### Re-deploying with existing credentials
+
+When re-running `setup-remote.sh` on an existing install, source `/opt/beads-web/.env` on the remote so SQL credentials don't go through your shell history:
+
+```bash
+ssh root@vps 'set -a; source /opt/beads-web/.env; set +a; \
+  bash -s -- \
+    --sql-user "$SQL_USER" --sql-password "$SQL_PASSWORD" \
+    --database "$DATABASE" --port 3008 \
+    --allow-ip YOUR_IP' \
+  < scripts/beads-web/setup-remote.sh
+```
+
+This idiom is useful any time you re-deploy without changing credentials (port migration, version upgrade, IP allowlist edits).
+
 ## Migrating Port
 
 If you have an existing deploy on a different port (the historical default was 9090; the current default is 3008) and want to switch:
@@ -254,6 +280,17 @@ Reads repo and version from existing `.env` file. No other arguments needed.
 - SQL user should have minimal grants (per-database only)
 
 ## Troubleshooting
+
+### Harmless warnings on startup
+
+On every start, beads-web logs:
+
+```
+WARN bd CLI not found. Searched PATH and: ... Install bd or add it to PATH.
+WARN ⚠ bd CLI not found - beads read/write will not work for filesystem projects
+```
+
+Safe to ignore for Dolt-only deploys. The warning fires because beads-web supports both filesystem (`.beads/`) and Dolt (`dolt://`) project backends. Filesystem mode requires the `bd` CLI inside the container; Dolt mode connects via SQL only. Our deploy is Dolt-only by design (see `data/.beads/metadata.json`), so the missing `bd` CLI never matters.
 
 ### Container won't start
 

--- a/scripts/beads-web/README.md
+++ b/scripts/beads-web/README.md
@@ -117,32 +117,48 @@ If you have an existing deploy on a different port (the historical default was 9
 
 > **Migrating from beads-ui (port 9080) instead?** beads-ui is deprecated and lives at `/opt/beads-ui/` - different install path, different cleanup. See [scripts/deprecated/beads-ui/README.md](../deprecated/beads-ui/README.md) for decommission steps before deploying beads-web.
 
+> **Order matters:** redeploy on the new port FIRST, then purge old-port firewall rules. The reverse order would leave the old container running on the old port without any firewall (open to internet) for the few seconds between purge and rebuild.
+
 ```bash
-# 1. Drop ALL firewall rules for the old port (ALLOWs from any IP + REJECT, v4 + v6).
-ssh root@vps "bash -s -- --purge-port 9090" \
+# 0. Pre-flight: confirm the new port is not already in use on the host.
+ssh root@vps "ss -tlnp | grep -q ':3008' && echo BUSY || echo '3008 free'"
+# Must show "3008 free" before continuing.
+
+# 1. Redeploy on the new port. Sources existing /opt/beads-web/.env so SQL
+#    credentials don't have to be retyped. Rebuild downs the old container,
+#    so the old port stops listening as a side effect.
+ssh root@vps 'set -a; source /opt/beads-web/.env; set +a; \
+  bash -s -- \
+    --sql-user "$SQL_USER" --sql-password "$SQL_PASSWORD" \
+    --database "$DATABASE" --port 3008 \
+    --allow-ip YOUR_IP_1 --allow-ip YOUR_IP_2' \
   < scripts/beads-web/setup-remote.sh
 
-# 2. Redeploy with the new port - same install dir, same data.
-ssh root@vps "bash -s -- \
-  --sql-user bdweb --sql-password your-password \
-  --database lets --port 3008 \
-  --allow-ip YOUR_IP" < scripts/beads-web/setup-remote.sh
+# 2. Verify new deployment BEFORE purging old port. If this fails, do NOT
+#    proceed - the rollback path needs the old firewall rules intact.
+ssh root@vps "
+  docker ps --filter name=beads-web --format '{{.Status}}'
+  curl -sf -o /dev/null -w 'HTTP: %{http_code}\n' http://localhost:3008/
+"
+# Must show "Up (healthy)" and "HTTP: 200".
+
+# 3. Purge old-port firewall rules (now that new deployment is verified).
+ssh root@vps "bash -s -- --purge-port 9090" \
+  < scripts/beads-web/setup-remote.sh
 ```
 
-Step 2 regenerates `docker-compose.yml`, `Dockerfile`, `.env`, and rebuilds the container. The volume-mounted `data/` (projects SQLite + Dolt metadata) is preserved.
+Step 1 regenerates `docker-compose.yml`, `Dockerfile`, `.env`, and rebuilds the container. The volume-mounted `data/` (projects SQLite + Dolt metadata) is preserved.
 
-After migration, verify the old port has no listeners and no firewall state:
+Final verification:
 
 ```bash
-ssh root@vps "ss -tlnp | grep ':9090'"            # should be empty
-ssh root@vps "iptables -L DOCKER-USER -n | grep 9090"   # should be empty
+ssh root@vps "ss -tlnp 2>/dev/null | grep ':9090' || echo 'OK: 9090 not listening'"
+ssh root@vps "iptables -L DOCKER-USER -n | grep 9090 || echo 'OK: 9090 firewall clean'"
 ```
 
-If either returns rows, re-run `--purge-port 9090` (it's idempotent). If still non-empty, inspect output and remove with `iptables -D DOCKER-USER <rule>`.
+**Rollback:** if Step 1 or 2 fails, redeploy on the old port with the original arguments (`--port 9090 --allow-ip YOUR_IP`). Skip Step 3. The install dir and data volume are preserved across both directions; the old port's firewall rules are still in place because we deferred the purge.
 
-**Rollback:** if Step 2 fails, redeploy on the old port with the original arguments (`--port 9090 --allow-ip YOUR_IP`). The install dir and data volume are preserved across both directions.
-
-> **Expected downtime:** Step 2 runs `docker compose build --no-cache` which re-downloads the binary from GitHub Releases. Total downtime is typically 30-90 seconds (build) + ~5-10 seconds (container recreate). Plan migrations outside business hours if uptime matters.
+> **Expected downtime:** Step 1 runs `docker compose build --no-cache` which re-downloads the binary from GitHub Releases. Total downtime is typically 30-90 seconds (build) + ~5-10 seconds (container recreate). Plan migrations outside business hours if uptime matters.
 
 ## IP Allowlist
 

--- a/scripts/beads-web/README.md
+++ b/scripts/beads-web/README.md
@@ -9,7 +9,7 @@ Source: [Shybko/beads-web](https://github.com/Shybko/beads-web) (fork of weselow
 ```
 Developer browser
      |
-http://VPS_IP:9090
+http://VPS_IP:3008
      |
 iptables DOCKER-USER (IP allowlist)
      |
@@ -46,7 +46,7 @@ See [scripts/dolt/README.md - Add SQL user](../dolt/README.md#add-sql-user).
 ```bash
 ssh root@vps "bash -s -- \
   --sql-user bdweb --sql-password your-password \
-  --database lets --port 9090 \
+  --database lets --port 3008 \
   --allow-ip YOUR_IP_1 --allow-ip YOUR_IP_2" \
   < scripts/beads-web/setup-remote.sh
 ```
@@ -57,12 +57,12 @@ beads-web supports multiple Dolt databases as separate projects. After deploy, a
 
 ```bash
 # Add a project (from VPS)
-docker exec beads-web curl -sf -X POST http://localhost:9090/api/projects \
+docker exec beads-web curl -sf -X POST http://localhost:3008/api/projects \
   -H 'Content-Type: application/json' \
   -d '{"name":"my-project","path":"dolt://mydb"}'
 
 # Add another project
-docker exec beads-web curl -sf -X POST http://localhost:9090/api/projects \
+docker exec beads-web curl -sf -X POST http://localhost:3008/api/projects \
   -H 'Content-Type: application/json' \
   -d '{"name":"another-project","path":"dolt://anotherdb"}'
 ```
@@ -74,7 +74,7 @@ The `dolt://` prefix tells beads-web to read/write via Dolt SQL. Each database o
 ### 4. Open in browser
 
 ```
-http://VPS_IP:9090
+http://VPS_IP:3008
 ```
 
 ## Updating
@@ -105,21 +105,54 @@ To upgrade to a new version (new release tag):
 ```bash
 ssh root@vps "bash -s -- \
   --sql-user bdweb --sql-password your-password \
-  --database lets --port 9090 \
+  --database lets --port 3008 \
   --version 1.0.0" < scripts/beads-web/setup-remote.sh
 ```
 
 The setup script is idempotent - it regenerates config and rebuilds the container.
 
+## Migrating Port
+
+If you have an existing deploy on a different port (the historical default was 9090; the current default is 3008) and want to switch:
+
+> **Migrating from beads-ui (port 9080) instead?** beads-ui is deprecated and lives at `/opt/beads-ui/` - different install path, different cleanup. See [scripts/deprecated/beads-ui/README.md](../deprecated/beads-ui/README.md) for decommission steps before deploying beads-web.
+
+```bash
+# 1. Drop ALL firewall rules for the old port (ALLOWs from any IP + REJECT, v4 + v6).
+ssh root@vps "bash -s -- --purge-port 9090" \
+  < scripts/beads-web/setup-remote.sh
+
+# 2. Redeploy with the new port - same install dir, same data.
+ssh root@vps "bash -s -- \
+  --sql-user bdweb --sql-password your-password \
+  --database lets --port 3008 \
+  --allow-ip YOUR_IP" < scripts/beads-web/setup-remote.sh
+```
+
+Step 2 regenerates `docker-compose.yml`, `Dockerfile`, `.env`, and rebuilds the container. The volume-mounted `data/` (projects SQLite + Dolt metadata) is preserved.
+
+After migration, verify the old port has no listeners and no firewall state:
+
+```bash
+ssh root@vps "ss -tlnp | grep ':9090'"            # should be empty
+ssh root@vps "iptables -L DOCKER-USER -n | grep 9090"   # should be empty
+```
+
+If either returns rows, re-run `--purge-port 9090` (it's idempotent). If still non-empty, inspect output and remove with `iptables -D DOCKER-USER <rule>`.
+
+**Rollback:** if Step 2 fails, redeploy on the old port with the original arguments (`--port 9090 --allow-ip YOUR_IP`). The install dir and data volume are preserved across both directions.
+
+> **Expected downtime:** Step 2 runs `docker compose build --no-cache` which re-downloads the binary from GitHub Releases. Total downtime is typically 30-90 seconds (build) + ~5-10 seconds (container recreate). Plan migrations outside business hours if uptime matters.
+
 ## IP Allowlist
 
 ```bash
 # Add IP
-ssh root@vps "bash -s -- --allow-ip 1.2.3.4 --port 9090" \
+ssh root@vps "bash -s -- --allow-ip 1.2.3.4 --port 3008" \
   < scripts/beads-web/setup-remote.sh
 
 # Remove IP
-ssh root@vps "bash -s -- --remove-ip 1.2.3.4 --port 9090" \
+ssh root@vps "bash -s -- --remove-ip 1.2.3.4 --port 3008" \
   < scripts/beads-web/setup-remote.sh
 ```
 
@@ -128,7 +161,7 @@ Multiple IPs can be added in a single command:
 ```bash
 ssh root@vps "bash -s -- \
   --allow-ip 1.2.3.4 --allow-ip 5.6.7.8 --allow-ip 9.10.11.12 \
-  --port 9090" < scripts/beads-web/setup-remote.sh
+  --port 3008" < scripts/beads-web/setup-remote.sh
 ```
 
 ## Fork Support
@@ -138,7 +171,7 @@ By default, the binary is downloaded from `Shybko/beads-web`. Use `--repo` to sp
 ```bash
 ssh root@vps "bash -s -- \
   --sql-user bdweb --sql-password your-password \
-  --database lets --port 9090 \
+  --database lets --port 3008 \
   --repo weselow/beads-web --version 1.0.0 \
   --allow-ip YOUR_IP" < scripts/beads-web/setup-remote.sh
 ```
@@ -168,9 +201,9 @@ ssh root@vps "bash -s -- \
 | --sql-user | - | SQL username for Dolt connection |
 | --sql-password | - | SQL password |
 | --database | - | Dolt database name (e.g., lets, aff) |
-| --allow-ip | - | Restrict access to this IP (repeatable) |
+| --allow-ip | - | Restrict access to this IP (single IPv4, no CIDR; repeatable for multiple IPs) |
 | --no-firewall | - | Leave port open to all (NOT recommended) |
-| --port | 9090 | Web UI port |
+| --port | 3008 | Web UI port |
 | --install-dir | /opt/beads-web | Installation directory |
 | --dolt-host | dolt | Dolt container hostname |
 | --dolt-port | 3306 | Dolt SQL port |
@@ -183,9 +216,10 @@ Either `--allow-ip` or `--no-firewall` is required - board has no built-in auth.
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| --allow-ip | - | Add IP to allowlist |
+| --allow-ip | - | Add IP to allowlist (single IPv4, no CIDR) |
 | --remove-ip | - | Remove IP from allowlist |
-| --port | 9090 | Target port |
+| --purge-port | - | Drop all ALLOW + REJECT rules for a port (decommission) |
+| --port | 3008 | Target port |
 
 ### update-remote.sh
 
@@ -222,7 +256,7 @@ docker network inspect dolt-net
 ### Port not accessible
 
 ```bash
-iptables -L DOCKER-USER -n | grep 9090
+iptables -L DOCKER-USER -n | grep 3008
 # Ensure your IP is in the allowlist
 ```
 

--- a/scripts/beads-web/setup-remote.sh
+++ b/scripts/beads-web/setup-remote.sh
@@ -172,8 +172,9 @@ purge_port_rules() {
     DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
   fi
   echo "Purging DOCKER-USER rules for port $port..."
-  while iptables -S DOCKER-USER 2>/dev/null | grep -q "dport $port .* -j ACCEPT"; do
-    rule=$(iptables -S DOCKER-USER 2>/dev/null | grep "dport $port .* -j ACCEPT" | head -1 | sed 's/^-A /-D /')
+  # Pattern matches `iptables -S` output: ` --dport PORT ... -j ACCEPT` at line end.
+  while iptables -S DOCKER-USER 2>/dev/null | grep -qE " --dport ${port} .*-j ACCEPT$"; do
+    rule=$(iptables -S DOCKER-USER 2>/dev/null | grep -E " --dport ${port} .*-j ACCEPT$" | head -1 | sed 's/^-A /-D /')
     [[ -z "$rule" ]] && break
     eval "iptables $rule" 2>/dev/null || break
   done

--- a/scripts/beads-web/setup-remote.sh
+++ b/scripts/beads-web/setup-remote.sh
@@ -6,26 +6,29 @@
 #   # Full install
 #   ssh root@vps "bash -s -- \
 #     --sql-user bdweb --sql-password secret \
-#     --database lets --port 9090 \
+#     --database lets --port 3008 \
 #     --allow-ip 1.2.3.4 --allow-ip 5.6.7.8" < scripts/beads-web/setup-remote.sh
 #
 #   # Different database on different port
 #   ssh root@vps "bash -s -- \
 #     --sql-user bdweb --sql-password secret \
-#     --database aff --port 9091 \
+#     --database aff --port 3009 \
 #     --install-dir /opt/beads-web-aff \
 #     --allow-ip 1.2.3.4" < scripts/beads-web/setup-remote.sh
 #
 #   # Custom fork
 #   ssh root@vps "bash -s -- \
 #     --sql-user bdweb --sql-password secret \
-#     --database lets --port 9090 \
+#     --database lets --port 3008 \
 #     --repo weselow/beads-web --version 1.0.0 \
 #     --allow-ip 1.2.3.4" < scripts/beads-web/setup-remote.sh
 #
 #   # Manage IP allowlist
-#   ssh root@vps "bash -s -- --allow-ip 1.2.3.4 --port 9090" < scripts/beads-web/setup-remote.sh
-#   ssh root@vps "bash -s -- --remove-ip 1.2.3.4 --port 9090" < scripts/beads-web/setup-remote.sh
+#   ssh root@vps "bash -s -- --allow-ip 1.2.3.4 --port 3008" < scripts/beads-web/setup-remote.sh
+#   ssh root@vps "bash -s -- --remove-ip 1.2.3.4 --port 3008" < scripts/beads-web/setup-remote.sh
+#
+#   # Decommission a port - drop all ALLOW + REJECT rules (e.g. when migrating off old port)
+#   ssh root@vps "bash -s -- --purge-port 9090" < scripts/beads-web/setup-remote.sh
 #
 # Prerequisites:
 #   - Docker installed (use scripts/dolt/setup-remote.sh first)
@@ -33,12 +36,13 @@
 #   - SQL user created in Dolt with grants on target database
 
 set -e
+umask 077  # `.env` (chmod 600 explicitly later) gets safe perms during creation window
 
 # ============================================
 # Configuration
 # ============================================
 INSTALL_DIR="${INSTALL_DIR:-/opt/beads-web}"
-BEADS_WEB_PORT="${BEADS_WEB_PORT:-9090}"
+BEADS_WEB_PORT="${BEADS_WEB_PORT:-3008}"
 BEADS_WEB_VERSION="${BEADS_WEB_VERSION:-latest}"
 BEADS_WEB_REPO="${BEADS_WEB_REPO:-Shybko/beads-web}"
 DOLT_HOST="${DOLT_HOST:-dolt}"
@@ -63,26 +67,20 @@ validate_name() {
 
 validate_ip() {
   local ip="$1"
-  if [[ ! "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?$ ]]; then
-    echo -e "${RED}Error: Invalid IP address format: $ip${NC}"
+  if [[ ! "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}Error: Invalid IP address: $ip (single IPv4 required, no CIDR/masks)${NC}"
     exit 1
   fi
-  # Validate octets
-  local addr cidr
-  IFS='/' read -r addr cidr <<< "$ip"
-  IFS='.' read -ra octets <<< "$addr"
+  local IFS='.'
+  local -a octets
+  read -ra octets <<< "$ip"
   for o in "${octets[@]}"; do
     if (( o > 255 )); then
       echo -e "${RED}Error: Invalid IP octet: $o in $ip${NC}"
       exit 1
     fi
   done
-  # Block wide CIDR ranges
-  if [[ -n "$cidr" ]] && (( cidr < 24 )); then
-    echo -e "${RED}Error: CIDR mask /$cidr is too wide (minimum /24)${NC}"
-    exit 1
-  fi
-  if [[ "$ip" == "0.0.0.0/0" || "$ip" == "0.0.0.0" ]]; then
+  if [[ "$ip" == "0.0.0.0" ]]; then
     echo -e "${RED}Error: Refusing 0.0.0.0 - this would open the port to everyone${NC}"
     exit 1
   fi
@@ -96,6 +94,7 @@ SQL_PASSWORD=""
 DATABASE=""
 ALLOW_IPS=()
 REMOVE_IP=""
+PURGE_PORT=""
 NO_FIREWALL=false
 
 while [[ $# -gt 0 ]]; do
@@ -111,6 +110,7 @@ while [[ $# -gt 0 ]]; do
     --version) BEADS_WEB_VERSION="$2"; shift 2 ;;
     --allow-ip) ALLOW_IPS+=("$2"); shift 2 ;;
     --remove-ip) REMOVE_IP="$2"; shift 2 ;;
+    --purge-port) PURGE_PORT="$2"; shift 2 ;;
     --no-firewall) NO_FIREWALL=true; shift ;;
     --) shift ;;
     *) echo -e "${RED}Unknown argument: $1${NC}"; exit 1 ;;
@@ -160,6 +160,40 @@ manage_ip_allowlist() {
   iptables -L DOCKER-USER -n --line-numbers 2>/dev/null | grep -E "dpt:$port|Chain"
 }
 
+# Purge all DOCKER-USER rules for a port (ALLOW from any source + REJECT v4/v6).
+# Used when fully decommissioning a port (migration, deprecation).
+purge_port_rules() {
+  local port="$1"
+  if [[ ! "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+    echo -e "${RED}Error: Invalid port: $port${NC}"
+    exit 1
+  fi
+  if ! dpkg -s iptables-persistent &>/dev/null; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
+  fi
+  echo "Purging DOCKER-USER rules for port $port..."
+  while iptables -S DOCKER-USER 2>/dev/null | grep -q "dport $port .* -j ACCEPT"; do
+    rule=$(iptables -S DOCKER-USER 2>/dev/null | grep "dport $port .* -j ACCEPT" | head -1 | sed 's/^-A /-D /')
+    [[ -z "$rule" ]] && break
+    eval "iptables $rule" 2>/dev/null || break
+  done
+  iptables -D DOCKER-USER -p tcp --dport "$port" -j REJECT --reject-with tcp-reset 2>/dev/null || true
+  ip6tables -D DOCKER-USER -p tcp --dport "$port" -j REJECT --reject-with tcp-reset 2>/dev/null || true
+  netfilter-persistent save 2>/dev/null || iptables-save > /etc/iptables/rules.v4
+  echo -e "${GREEN}Purged all DOCKER-USER rules for port $port${NC}"
+  remaining=$(iptables -L DOCKER-USER -n 2>/dev/null | grep -c "dpt:$port" || true)
+  if (( remaining > 0 )); then
+    echo -e "${YELLOW}Warning: $remaining rule(s) still present for port $port:${NC}"
+    iptables -L DOCKER-USER -n 2>/dev/null | grep "dpt:$port"
+  fi
+}
+
+# --purge-port mode (standalone)
+if [[ -n "$PURGE_PORT" ]]; then
+  purge_port_rules "$PURGE_PORT"
+  exit 0
+fi
+
 # --remove-ip mode (standalone)
 if [[ -n "$REMOVE_IP" ]]; then
   validate_ip "$REMOVE_IP"
@@ -194,6 +228,7 @@ if [[ -z "$DATABASE" ]]; then
   echo "  Full install:   $0 --sql-user USER --sql-password PASS --database DB --allow-ip IP"
   echo "  Add IP:         $0 --allow-ip IP --port PORT"
   echo "  Remove IP:      $0 --remove-ip IP --port PORT"
+  echo "  Purge port:     $0 --purge-port PORT      # decommission - drops all rules"
   echo ""
   echo "Full install:"
   echo "  --sql-user USER        SQL username for Dolt connection"
@@ -203,17 +238,18 @@ if [[ -z "$DATABASE" ]]; then
   echo "  --no-firewall          Leave port open to all (NOT recommended)"
   echo ""
   echo "  Optional:"
-  echo "  --port PORT            Web UI port (default: 9090)"
+  echo "  --port PORT            Web UI port (default: 3008)"
   echo "  --install-dir DIR      Install directory (default: /opt/beads-web)"
   echo "  --dolt-host HOST       Dolt hostname (default: dolt)"
   echo "  --dolt-port PORT       Dolt SQL port (default: 3306)"
   echo "  --repo OWNER/REPO      GitHub repo for binary (default: Shybko/beads-web)"
   echo "  --version VER          beads-web version or 'latest' (default: latest)"
   echo ""
-  echo "IP management (standalone):"
-  echo "  --allow-ip IP          Add IP to allowlist"
+  echo "IP / port management (standalone):"
+  echo "  --allow-ip IP          Add IP to allowlist (single IPv4, no CIDR)"
   echo "  --remove-ip IP         Remove IP from allowlist"
-  echo "  --port PORT            Target port (default: 9090)"
+  echo "  --purge-port PORT      Drop all ALLOW + REJECT rules for a port"
+  echo "  --port PORT            Target port (default: 3008)"
   exit 1
 fi
 
@@ -230,8 +266,17 @@ if [[ -f "$INSTALL_DIR/.env" ]]; then
   echo -e "${YELLOW}Existing installation found at $INSTALL_DIR${NC}"
   existing_version=$(grep '^BEADS_WEB_VERSION=' "$INSTALL_DIR/.env" | cut -d= -f2)
   existing_repo=$(grep '^BEADS_WEB_REPO=' "$INSTALL_DIR/.env" | cut -d= -f2)
+  existing_port=$(grep '^BEADS_WEB_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2)
   BEADS_WEB_VERSION="${BEADS_WEB_VERSION:-$existing_version}"
   BEADS_WEB_REPO="${BEADS_WEB_REPO:-$existing_repo}"
+  # Warn on port change - manage_ip_allowlist scopes to the new port only,
+  # so old port's ALLOW/REJECT rules linger. Operator should follow the
+  # "Migrating Port" runbook (README) before redeploying on a new port.
+  if [[ -n "$existing_port" && "$existing_port" != "$BEADS_WEB_PORT" ]]; then
+    echo -e "${YELLOW}WARNING: Port change detected: $existing_port -> $BEADS_WEB_PORT${NC}"
+    echo -e "${YELLOW}  Old port's iptables rules will not be cleaned up automatically.${NC}"
+    echo -e "${YELLOW}  See README 'Migrating Port' section before continuing if this is unexpected.${NC}"
+  fi
 fi
 
 # Build release URL
@@ -284,16 +329,18 @@ create_config() {
   chown -R 1000:1000 "$INSTALL_DIR/data"
 
   # Dockerfile
-  cat > "$INSTALL_DIR/Dockerfile" <<DOCKERFILE
+  # Quoted heredoc tag (<<'DOCKERFILE') prevents host-shell expansion of ${...} and
+  # joining of \-newline. RELEASE_URL is passed as build arg by docker-compose.
+  cat > "$INSTALL_DIR/Dockerfile" <<'DOCKERFILE'
 FROM debian:trixie-slim
 
-ARG RELEASE_URL=${RELEASE_URL}
+ARG RELEASE_URL
 
-RUN apt-get update && apt-get install -y --no-install-recommends \\
-    curl ca-certificates \\
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fSL -o /usr/local/bin/beads-web "\${RELEASE_URL}" \\
+RUN curl -fSL -o /usr/local/bin/beads-web "${RELEASE_URL}" \
     && chmod +x /usr/local/bin/beads-web
 
 RUN useradd --uid 1000 --system --create-home beadsweb \
@@ -302,10 +349,10 @@ RUN useradd --uid 1000 --system --create-home beadsweb \
 WORKDIR /app
 USER beadsweb
 
-EXPOSE 9090
+EXPOSE 3008
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 --start-period=10s \
-  CMD curl -sf http://localhost:${PORT:-9090}/ || exit 1
+  CMD curl -sf http://localhost:${PORT:-3008}/ || exit 1
 
 CMD ["beads-web"]
 DOCKERFILE
@@ -322,12 +369,12 @@ services:
     container_name: beads-web
     restart: unless-stopped
     ports:
-      - "\${BEADS_WEB_PORT:-9090}:\${BEADS_WEB_PORT:-9090}"
+      - "\${BEADS_WEB_PORT:-3008}:\${BEADS_WEB_PORT:-3008}"
     volumes:
       - ./data/.beads:/app/.beads
       - ./data/kanban-ui:/home/beadsweb/.local/share/kanban-ui
     environment:
-      - PORT=\${BEADS_WEB_PORT:-9090}
+      - PORT=\${BEADS_WEB_PORT:-3008}
       - DOLT_HOST=\${DOLT_HOST:-dolt}
       - DOLT_PORT=\${DOLT_PORT:-3306}
       - DOLT_USER=\${SQL_USER}
@@ -455,7 +502,7 @@ print_summary() {
   echo ""
   echo "Add another database:"
   echo "  $0 --sql-user USER --sql-password PASS \\"
-  echo "    --database aff --port 9091 \\"
+  echo "    --database aff --port 3009 \\"
   echo "    --install-dir /opt/beads-web-aff \\"
   echo "    --allow-ip <IP>"
   echo ""

--- a/scripts/deprecated/README.md
+++ b/scripts/deprecated/README.md
@@ -1,0 +1,17 @@
+# scripts/deprecated/
+
+Tools no longer used. Kept for two reasons:
+
+1. **Historical reference** - implementation details and design decisions for review.
+2. **Decommission runbooks** - operators still running these on a VPS need cleanup steps in the subdirectory READMEs.
+
+Each subdir's README opens with a `DEPRECATED` banner, points to the replacement, and documents VPS cleanup if applicable.
+
+**Do not deploy from here.** Use the active tools in `scripts/`.
+
+## Current contents
+
+| Subdir | Replaced by | Reason |
+|---|---|---|
+| `beads-ui/` | `scripts/beads-web/` | Node.js dashboard (port 9080) superseded by Rust/Axum binary (port 3008) - faster, broader feature set |
+| `beads/` | Direct SQL via `scripts/dolt/setup-remote.sh` | Legacy push/pull mode (remotesapi); Direct SQL is the recommended deployment now |

--- a/scripts/deprecated/beads-ui/README.md
+++ b/scripts/deprecated/beads-ui/README.md
@@ -1,4 +1,36 @@
-# beads-ui - Web Dashboard
+# beads-ui - Web Dashboard (DEPRECATED)
+
+> **DEPRECATED.** Superseded by [beads-web](../../beads-web/). Use `scripts/beads-web/` for new deploys.
+>
+> beads-ui is the legacy Node.js dashboard (port 9080). beads-web is the Rust/Axum-based replacement (port 3008): single binary with embedded frontend, faster, broader feature set (Dolt cache, donut chart, labels filter).
+>
+> This folder is kept for historical reference and to document the VPS cleanup runbook below. Do not use for new installs.
+
+## VPS Cleanup Runbook
+
+If beads-ui is still running on a VPS, decommission it:
+
+```bash
+# 1. Stop and remove container + image
+ssh root@vps "cd /opt/beads-ui && docker compose down --rmi all -v"
+
+# 2. Drop ALL firewall rules for the port (ALLOWs from any IP + REJECT, v4 + v6).
+ssh root@vps "bash -s -- --purge-port 9080" \
+  < scripts/deprecated/beads-ui/setup-remote.sh
+
+# 3. Remove install directory
+ssh root@vps "rm -rf /opt/beads-ui /opt/beads-ui-*"
+
+# 4. Verify nothing listens on 9080
+ssh root@vps "ss -tlnp | grep ':9080'"   # should be empty
+ssh root@vps "iptables -L DOCKER-USER -n | grep 9080"  # should be empty
+```
+
+The Dolt container and `dolt-net` Docker network are NOT removed - they are shared with beads-web and stay.
+
+---
+
+# Original Documentation (legacy)
 
 Web dashboard for beads issue tracker. Runs in Docker, connects to Dolt SQL server.
 
@@ -26,7 +58,7 @@ iptables DOCKER-USER (IP allowlist)
 
 ### 1. Create SQL user in Dolt (if not exists)
 
-See [scripts/dolt/README.md - Add SQL user](../dolt/README.md#add-sql-user).
+See [scripts/dolt/README.md - Add SQL user](../../dolt/README.md#add-sql-user).
 
 ### 2. Deploy beads-ui
 
@@ -35,7 +67,7 @@ ssh root@vps "bash -s -- \
   --sql-user bdui --sql-password your-password \
   --database lets --port 9080 \
   --allow-ip YOUR_IP_1 --allow-ip YOUR_IP_2" \
-  < scripts/beads-ui/setup-remote.sh
+  < scripts/deprecated/beads-ui/setup-remote.sh
 ```
 
 ### 3. Open in browser
@@ -51,7 +83,7 @@ ssh root@vps "bash -s -- \
   --sql-user bdui --sql-password your-password \
   --database aff --port 9081 \
   --install-dir /opt/beads-ui-aff \
-  --allow-ip YOUR_IP" < scripts/beads-ui/setup-remote.sh
+  --allow-ip YOUR_IP" < scripts/deprecated/beads-ui/setup-remote.sh
 ```
 
 ## IP Allowlist
@@ -59,11 +91,11 @@ ssh root@vps "bash -s -- \
 ```bash
 # Add IP
 ssh root@vps "bash -s -- --allow-ip 1.2.3.4 --port 9080" \
-  < scripts/beads-ui/setup-remote.sh
+  < scripts/deprecated/beads-ui/setup-remote.sh
 
 # Remove IP
 ssh root@vps "bash -s -- --remove-ip 1.2.3.4 --port 9080" \
-  < scripts/beads-ui/setup-remote.sh
+  < scripts/deprecated/beads-ui/setup-remote.sh
 ```
 
 ## Upgrading
@@ -72,7 +104,7 @@ ssh root@vps "bash -s -- --remove-ip 1.2.3.4 --port 9080" \
 ssh root@vps "bash -s -- \
   --sql-user bdui --sql-password your-password \
   --database lets --port 9080 \
-  --version 0.12.0" < scripts/beads-ui/setup-remote.sh
+  --version 0.12.0" < scripts/deprecated/beads-ui/setup-remote.sh
 ```
 
 The script is idempotent - it rebuilds the container with the new version.

--- a/scripts/deprecated/beads-ui/setup-remote.sh
+++ b/scripts/deprecated/beads-ui/setup-remote.sh
@@ -159,8 +159,9 @@ purge_port_rules() {
     DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
   fi
   echo "Purging DOCKER-USER rules for port $port..."
-  while iptables -S DOCKER-USER 2>/dev/null | grep -q "dport $port .* -j ACCEPT"; do
-    rule=$(iptables -S DOCKER-USER 2>/dev/null | grep "dport $port .* -j ACCEPT" | head -1 | sed 's/^-A /-D /')
+  # Pattern matches `iptables -S` output: ` --dport PORT ... -j ACCEPT` at line end.
+  while iptables -S DOCKER-USER 2>/dev/null | grep -qE " --dport ${port} .*-j ACCEPT$"; do
+    rule=$(iptables -S DOCKER-USER 2>/dev/null | grep -E " --dport ${port} .*-j ACCEPT$" | head -1 | sed 's/^-A /-D /')
     [[ -z "$rule" ]] && break
     eval "iptables $rule" 2>/dev/null || break
   done

--- a/scripts/deprecated/beads-ui/setup-remote.sh
+++ b/scripts/deprecated/beads-ui/setup-remote.sh
@@ -55,26 +55,20 @@ validate_name() {
 
 validate_ip() {
   local ip="$1"
-  if [[ ! "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?$ ]]; then
-    echo -e "${RED}Error: Invalid IP address format: $ip${NC}"
+  if [[ ! "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}Error: Invalid IP address: $ip (single IPv4 required, no CIDR/masks)${NC}"
     exit 1
   fi
-  # Validate octets
-  local addr cidr
-  IFS='/' read -r addr cidr <<< "$ip"
-  IFS='.' read -ra octets <<< "$addr"
+  local IFS='.'
+  local -a octets
+  read -ra octets <<< "$ip"
   for o in "${octets[@]}"; do
     if (( o > 255 )); then
       echo -e "${RED}Error: Invalid IP octet: $o in $ip${NC}"
       exit 1
     fi
   done
-  # Block wide CIDR ranges
-  if [[ -n "$cidr" ]] && (( cidr < 24 )); then
-    echo -e "${RED}Error: CIDR mask /$cidr is too wide (minimum /24)${NC}"
-    exit 1
-  fi
-  if [[ "$ip" == "0.0.0.0/0" || "$ip" == "0.0.0.0" ]]; then
+  if [[ "$ip" == "0.0.0.0" ]]; then
     echo -e "${RED}Error: Refusing 0.0.0.0 - this would open the port to everyone${NC}"
     exit 1
   fi
@@ -88,6 +82,7 @@ SQL_PASSWORD=""
 DATABASE=""
 ALLOW_IPS=()
 REMOVE_IP=""
+PURGE_PORT=""
 NO_FIREWALL=false
 
 while [[ $# -gt 0 ]]; do
@@ -102,6 +97,7 @@ while [[ $# -gt 0 ]]; do
     --version) BEADS_UI_VERSION="$2"; shift 2 ;;
     --allow-ip) ALLOW_IPS+=("$2"); shift 2 ;;
     --remove-ip) REMOVE_IP="$2"; shift 2 ;;
+    --purge-port) PURGE_PORT="$2"; shift 2 ;;
     --no-firewall) NO_FIREWALL=true; shift ;;
     --) shift ;;
     *) echo -e "${RED}Unknown argument: $1${NC}"; exit 1 ;;
@@ -150,6 +146,40 @@ manage_ip_allowlist() {
   echo "Current allowlist for port $port:"
   iptables -L DOCKER-USER -n --line-numbers 2>/dev/null | grep -E "dpt:$port|Chain"
 }
+
+# Purge all DOCKER-USER rules for a port (ALLOW from any source + REJECT v4/v6).
+# Used when fully decommissioning a port (deprecation cleanup).
+purge_port_rules() {
+  local port="$1"
+  if [[ ! "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+    echo -e "${RED}Error: Invalid port: $port${NC}"
+    exit 1
+  fi
+  if ! dpkg -s iptables-persistent &>/dev/null; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
+  fi
+  echo "Purging DOCKER-USER rules for port $port..."
+  while iptables -S DOCKER-USER 2>/dev/null | grep -q "dport $port .* -j ACCEPT"; do
+    rule=$(iptables -S DOCKER-USER 2>/dev/null | grep "dport $port .* -j ACCEPT" | head -1 | sed 's/^-A /-D /')
+    [[ -z "$rule" ]] && break
+    eval "iptables $rule" 2>/dev/null || break
+  done
+  iptables -D DOCKER-USER -p tcp --dport "$port" -j REJECT --reject-with tcp-reset 2>/dev/null || true
+  ip6tables -D DOCKER-USER -p tcp --dport "$port" -j REJECT --reject-with tcp-reset 2>/dev/null || true
+  netfilter-persistent save 2>/dev/null || iptables-save > /etc/iptables/rules.v4
+  echo -e "${GREEN}Purged all DOCKER-USER rules for port $port${NC}"
+  remaining=$(iptables -L DOCKER-USER -n 2>/dev/null | grep -c "dpt:$port" || true)
+  if (( remaining > 0 )); then
+    echo -e "${YELLOW}Warning: $remaining rule(s) still present for port $port:${NC}"
+    iptables -L DOCKER-USER -n 2>/dev/null | grep "dpt:$port"
+  fi
+}
+
+# --purge-port mode (standalone)
+if [[ -n "$PURGE_PORT" ]]; then
+  purge_port_rules "$PURGE_PORT"
+  exit 0
+fi
 
 # --remove-ip mode (standalone)
 if [[ -n "$REMOVE_IP" ]]; then

--- a/scripts/deprecated/beads/setup-beads-remote.sh
+++ b/scripts/deprecated/beads/setup-beads-remote.sh
@@ -5,8 +5,8 @@
 #
 # Beads Remote Setup - connects local beads to shared GitHub remote.
 #
-# Run after cloning the project:
-#   scripts/beads/setup-beads-remote.sh
+# Run after cloning the project (legacy push/pull mode):
+#   scripts/deprecated/beads/setup-beads-remote.sh
 #
 # What it does:
 #   1. Inits dolt database, starts sql-server, runs bd init

--- a/scripts/dolt/README.md
+++ b/scripts/dolt/README.md
@@ -83,11 +83,14 @@ ssh root@vps "bash -s -- --add-repo new-project" < scripts/dolt/setup-remote.sh
 Access to SQL port 3306 is restricted by IP. Only allowed IPs can connect.
 
 ```bash
-# Allow an IP
+# Allow an IP (single IPv4 only - no CIDR/masks)
 ssh root@vps "bash -s -- --allow-ip 1.2.3.4" < scripts/dolt/setup-remote.sh
 
 # Remove an IP
 ssh root@vps "bash -s -- --remove-ip 1.2.3.4" < scripts/dolt/setup-remote.sh
+
+# Decommission the port entirely (drop all ALLOW + REJECT rules for the port)
+ssh root@vps "bash -s -- --purge-port 3306" < scripts/dolt/setup-remote.sh
 
 # Check current rules
 ssh root@vps "iptables -L DOCKER-USER -n --line-numbers | grep 3306"
@@ -191,19 +194,82 @@ If connection works, you'll see tasks. No local dolt server needed.
 5. Set env vars if not already in shell profile (see Client Setup)
 6. Run `bd list` to verify
 
-## Backup
+## Backups
 
-Daily backup cron on VPS (keeps 7 days):
+Two layers:
+
+1. **VPS-level snapshots** (host provides daily + weekly snapshots of whole VPS) - the disaster-recovery layer. Restore the entire VPS state.
+2. **Application-aware snapshot** via `scripts/dolt/backup-remote.sh` - operator-initiated, point-in-time snapshot of just `/opt/dolt-remote/` for **before-risky-op** scenarios (migrations, version bumps, ad-hoc DDL). Single tarball, fast restore without rolling back the whole VPS.
+
+This section documents layer 2.
+
+### When to use
+
+Run before any operation that would be hard to roll back via VPS-snap alone:
+- `setup-remote.sh` re-run with config changes
+- `DOLT_VERSION` bump
+- Manual SQL migrations or schema changes
+- Bulk `bd` operations that affect many issues at once
+
+### Run a backup
 
 ```bash
-ssh root@vps "mkdir -p /opt/dolt-backups && \
-  (crontab -l 2>/dev/null; echo '0 3 * * * tar czf /opt/dolt-backups/\$(date +\%F).tar.gz -C /opt/dolt-remote dolt-home/ && find /opt/dolt-backups -mtime +7 -delete >> /var/log/dolt-backup.log 2>&1') | crontab -"
+ssh root@vps "bash -s" < scripts/dolt/backup-remote.sh
+```
+
+The container stops for ~5-15 seconds. Full state lands in `/opt/dolt-remote/backups/dolt-backup-YYYYMMDD-HHMMSS.tar.gz` (chmod 600 - contains `.env` with `ROOT_PASSWORD`).
+
+Custom output dir:
+```bash
+ssh root@vps "bash -s -- --output-dir /mnt/backups" < scripts/dolt/backup-remote.sh
+```
+
+### Verify a backup
+
+```bash
+ssh root@vps "gzip -t /opt/dolt-remote/backups/dolt-backup-*.tar.gz && \
+              tar -tzf /opt/dolt-remote/backups/dolt-backup-YYYYMMDD-HHMMSS.tar.gz | head"
+```
+
+Expected: no errors from `gzip -t`; tar listing shows `dolt-home/`, `.env`, `docker-compose.yml`, `servercfg.d/`.
+
+### Restore from backup
+
+The tarball contains the entire deployment. Restore replaces the install dir's contents in-place (preserves only `backups/`):
+
+```bash
+ssh root@vps "
+  set -e
+  cd /opt/dolt-remote
+  docker compose down
+  find . -mindepth 1 -maxdepth 1 ! -name backups -exec rm -rf {} +
+  tar -xzf backups/dolt-backup-YYYYMMDD-HHMMSS.tar.gz
+  chmod 600 .env
+  docker compose up -d
+"
 ```
 
 Verify:
 ```bash
-ssh root@vps "crontab -l | grep dolt"
+ssh root@vps "docker exec dolt dolt sql -q 'SHOW DATABASES;'"
 ```
+
+> **Note:** dependent services (e.g., `beads-web`) keep running but may briefly fail until Dolt finishes booting (~5-10s). The `dolt-net` Docker network is preserved.
+
+### Manage backups
+
+There is no automatic retention. Delete tarballs you no longer want:
+
+```bash
+ssh root@vps "ls -lh /opt/dolt-remote/backups/"
+ssh root@vps "rm /opt/dolt-remote/backups/dolt-backup-YYYYMMDD-HHMMSS.tar.gz"
+```
+
+Long-term retention is covered by the VPS-level snapshot system; this script is for short-lived "before-risky-op" snapshots only.
+
+### Troubleshooting
+
+If the backup script exits with `dolt did not reach healthy state in 60s`: the tarball is still valid (chmod 600, gzip-tested). Inspect `docker logs dolt` before relying on the running container; the backup itself is safe to keep.
 
 ## Server Layout
 
@@ -323,4 +389,4 @@ ssh root@vps "cd /opt/dolt-remote && docker compose down -v && rm -rf dolt-home 
 
 ## Legacy: RemotesAPI (push/pull)
 
-The older push/pull architecture is still available via remotesapi on port 50051 (localhost only when `--expose-sql` is used). See `scripts/beads/setup-beads-remote.sh` for the client-side setup. This mode requires a local dolt server and is no longer recommended.
+The older push/pull architecture is still available via remotesapi on port 50051 (localhost only when `--expose-sql` is used). See `scripts/deprecated/beads/setup-beads-remote.sh` for the client-side setup (now archived under `scripts/deprecated/`). This mode requires a local dolt server and is no longer recommended.

--- a/scripts/dolt/backup-remote.sh
+++ b/scripts/dolt/backup-remote.sh
@@ -1,0 +1,175 @@
+#!/bin/bash
+# Dolt Remote Server - Ad-hoc backup
+# Single-tarball snapshot of /opt/dolt-remote/ (data + privileges + .env + compose).
+# Stops the dolt container briefly for consistent state.
+#
+# Use case: operator-initiated snapshot before risky operations (migrations, version
+# bumps, ad-hoc DDL). NOT a scheduled/retention tool - VPS-level snapshots cover that.
+#
+# Usage:
+#   # Default: stop container, snapshot to /opt/dolt-remote/backups/
+#   ssh root@vps "bash -s" < scripts/dolt/backup-remote.sh
+#
+#   # Custom output dir
+#   ssh root@vps "bash -s -- --output-dir /mnt/backups" < scripts/dolt/backup-remote.sh
+#
+# Restore: see scripts/dolt/README.md "Restore from backup" section.
+
+set -e
+umask 077  # tarball + sidecar files default to 600/700
+
+# ============================================
+# Configuration
+# ============================================
+INSTALL_DIR="${INSTALL_DIR:-/opt/dolt-remote}"
+OUTPUT_DIR=""
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+# ============================================
+# Parse args
+# ============================================
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install-dir) INSTALL_DIR="$2"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
+    --help|-h)
+      echo "Usage: $0 [--install-dir DIR] [--output-dir DIR]"
+      echo ""
+      echo "Ad-hoc backup of Dolt SQL server. Stops container briefly for consistency."
+      echo ""
+      echo "Options:"
+      echo "  --install-dir DIR   Dolt install dir (default: /opt/dolt-remote)"
+      echo "  --output-dir DIR    Backup output dir (default: <install-dir>/backups)"
+      echo ""
+      echo "Output: dolt-backup-YYYYMMDD-HHMMSS.tar.gz (chmod 600, contains .env)"
+      exit 0
+      ;;
+    --) shift ;;
+    *) echo -e "${RED}Unknown argument: $1${NC}"; exit 1 ;;
+  esac
+done
+
+OUTPUT_DIR="${OUTPUT_DIR:-$INSTALL_DIR/backups}"
+
+# ============================================
+# Pre-flight
+# ============================================
+if [ "$EUID" -ne 0 ]; then
+  echo -e "${RED}Error: Please run as root${NC}"
+  exit 1
+fi
+
+if [[ ! -d "$INSTALL_DIR/dolt-home" ]]; then
+  echo -e "${RED}Error: $INSTALL_DIR/dolt-home not found. Is dolt installed here?${NC}"
+  exit 1
+fi
+
+if [[ ! -f "$INSTALL_DIR/docker-compose.yml" ]]; then
+  echo -e "${RED}Error: $INSTALL_DIR/docker-compose.yml not found${NC}"
+  exit 1
+fi
+
+mkdir -p "$OUTPUT_DIR"
+chmod 700 "$OUTPUT_DIR"
+
+# ============================================
+# Plan the backup
+# ============================================
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+TARBALL="$OUTPUT_DIR/dolt-backup-${TIMESTAMP}.tar.gz"
+
+# Compute tar exclude path. If OUTPUT_DIR is inside INSTALL_DIR, build a relative
+# path (handles arbitrary nesting). If outside, no exclude needed.
+OUTPUT_ABS=$(readlink -f "$OUTPUT_DIR")
+INSTALL_ABS=$(readlink -f "$INSTALL_DIR")
+if [[ "$OUTPUT_ABS" == "$INSTALL_ABS" ]]; then
+  echo -e "${RED}Error: --output-dir must not equal --install-dir (would create a recursive tarball)${NC}"
+  exit 1
+fi
+TAR_EXCLUDES=()
+if [[ "$OUTPUT_ABS" == "$INSTALL_ABS"/* ]]; then
+  REL="${OUTPUT_ABS#$INSTALL_ABS/}"
+  TAR_EXCLUDES+=("--exclude=./${REL}")
+fi
+
+echo ""
+echo -e "${GREEN}=== Dolt Backup ===${NC}"
+echo ""
+echo "  Install dir: $INSTALL_DIR"
+echo "  Output:      $TARBALL"
+echo ""
+
+# ============================================
+# Stop, snapshot, restart - with safety trap
+# ============================================
+cd "$INSTALL_DIR"
+
+echo -e "${YELLOW}[1/3] Stopping dolt container...${NC}"
+docker compose stop dolt
+STOP_TS=$(date +%s)
+
+# Trap: if anything below fails, ensure dolt is restarted before script exits.
+# Cleared after successful start.
+restart_on_exit() {
+  local rc=$?
+  if [[ $rc -ne 0 ]]; then
+    echo -e "${RED}Backup failed (exit $rc). Restarting dolt container...${NC}"
+    docker compose start dolt 2>/dev/null || \
+      echo -e "${RED}CRITICAL: dolt restart also failed - manual intervention needed${NC}"
+    rm -f "$TARBALL" 2>/dev/null  # don't leave a partial tarball
+  fi
+}
+trap restart_on_exit EXIT
+
+echo -e "${YELLOW}[2/3] Creating tarball...${NC}"
+tar -czf "$TARBALL" "${TAR_EXCLUDES[@]}" -C "$INSTALL_DIR" .
+chmod 600 "$TARBALL"
+
+echo -e "${YELLOW}[3/3] Restarting dolt container...${NC}"
+docker compose start dolt
+START_TS=$(date +%s)
+DOWNTIME=$((START_TS - STOP_TS))
+
+trap - EXIT  # success path - cancel safety trap
+
+# Wait for healthy - 60s budget covers start_period (15s) + first interval (30s).
+echo "  Waiting for dolt to become healthy..."
+STATUS=""
+for _ in $(seq 1 30); do
+  sleep 2
+  STATUS=$(docker inspect dolt --format '{{.State.Health.Status}}' 2>/dev/null || echo "")
+  if [[ "$STATUS" == "healthy" ]]; then
+    break
+  fi
+done
+if [[ "$STATUS" != "healthy" ]]; then
+  echo -e "${RED}ERROR: dolt did not reach healthy state in 60s. Backup tarball is OK,${NC}"
+  echo -e "${RED}  but check 'docker logs dolt' before relying on the running container.${NC}"
+  exit 1
+fi
+
+# Sanity-verify the tarball is readable. Cheap (~50ms per 50MB).
+if ! gzip -t "$TARBALL" 2>/dev/null; then
+  echo -e "${RED}ERROR: tarball failed gzip integrity check.${NC}"
+  echo -e "${RED}  This is likely truncation (disk full?). Tarball at: $TARBALL${NC}"
+  exit 1
+fi
+
+SIZE=$(du -h "$TARBALL" | awk '{print $1}')
+echo ""
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}    Dolt Backup Complete${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo "  File:        $TARBALL"
+echo "  Size:        $SIZE"
+echo "  Downtime:    ${DOWNTIME}s"
+echo ""
+echo "Restore: see scripts/dolt/README.md 'Restore from backup' section."
+echo "Manage:  delete unwanted backups with 'rm $OUTPUT_DIR/dolt-backup-*.tar.gz'"
+echo -e "${GREEN}========================================${NC}"

--- a/scripts/dolt/setup-remote.sh
+++ b/scripts/dolt/setup-remote.sh
@@ -16,6 +16,9 @@
 #   ssh root@vps "bash -s -- --allow-ip 1.2.3.4" < scripts/dolt/setup-remote.sh
 #   ssh root@vps "bash -s -- --remove-ip 1.2.3.4" < scripts/dolt/setup-remote.sh
 #
+#   # Decommission a port - drop all ALLOW + REJECT rules (e.g. when retiring this service)
+#   ssh root@vps "bash -s -- --purge-port 3306" < scripts/dolt/setup-remote.sh
+#
 # Architecture:
 #   One Dolt container serves ALL databases via data_dir volume.
 #   Direct SQL: clients connect to port 3306 via MySQL protocol.
@@ -25,6 +28,7 @@
 #   Per-user SQL accounts. Create users via MySQL protocol (see README).
 
 set -e
+umask 077  # `.env` (chmod 600 explicitly later) gets safe perms during creation window
 
 # ============================================
 # Configuration
@@ -52,11 +56,20 @@ validate_name() {
 
 validate_ip() {
   local ip="$1"
-  if [[ ! "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+(/[0-9]+)?$ ]]; then
-    echo -e "${RED}Error: Invalid IP address format: $ip${NC}"
+  if [[ ! "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo -e "${RED}Error: Invalid IP address: $ip (single IPv4 required, no CIDR/masks)${NC}"
     exit 1
   fi
-  if [[ "$ip" == "0.0.0.0/0" || "$ip" == "0.0.0.0" ]]; then
+  local IFS='.'
+  local -a octets
+  read -ra octets <<< "$ip"
+  for o in "${octets[@]}"; do
+    if (( o > 255 )); then
+      echo -e "${RED}Error: Invalid IP octet: $o in $ip${NC}"
+      exit 1
+    fi
+  done
+  if [[ "$ip" == "0.0.0.0" ]]; then
     echo -e "${RED}Error: Refusing 0.0.0.0 - this would open the port to everyone${NC}"
     exit 1
   fi
@@ -70,6 +83,7 @@ ROOT_PASSWORD=""
 EXPOSE_SQL=false
 ALLOW_IP=""
 REMOVE_IP=""
+PURGE_PORT=""
 REPOS=()
 
 while [[ $# -gt 0 ]]; do
@@ -79,6 +93,7 @@ while [[ $# -gt 0 ]]; do
     --expose-sql) EXPOSE_SQL=true; shift ;;
     --allow-ip) ALLOW_IP="$2"; shift 2 ;;
     --remove-ip) REMOVE_IP="$2"; shift 2 ;;
+    --purge-port) PURGE_PORT="$2"; shift 2 ;;
     --) shift ;;
     *) REPOS+=("$1"); shift ;;
   esac
@@ -127,6 +142,42 @@ manage_ip_allowlist() {
   iptables -L DOCKER-USER -n --line-numbers 2>/dev/null | grep -E "dpt:$port|Chain"
 }
 
+# Purge all DOCKER-USER rules for a port (ALLOW from any source + REJECT v4/v6).
+# Used when fully decommissioning a port (migration, deprecation).
+purge_port_rules() {
+  local port="$1"
+  if [[ ! "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+    echo -e "${RED}Error: Invalid port: $port${NC}"
+    exit 1
+  fi
+  if ! dpkg -s iptables-persistent &>/dev/null; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
+  fi
+  echo "Purging DOCKER-USER rules for port $port..."
+  # Drop all ALLOW rules (any source) - iterate by re-querying to handle multi-IP
+  while iptables -S DOCKER-USER 2>/dev/null | grep -q "dport $port .* -j ACCEPT"; do
+    rule=$(iptables -S DOCKER-USER 2>/dev/null | grep "dport $port .* -j ACCEPT" | head -1 | sed 's/^-A /-D /')
+    [[ -z "$rule" ]] && break
+    eval "iptables $rule" 2>/dev/null || break
+  done
+  # Drop REJECT (v4 + v6)
+  iptables -D DOCKER-USER -p tcp --dport "$port" -j REJECT --reject-with tcp-reset 2>/dev/null || true
+  ip6tables -D DOCKER-USER -p tcp --dport "$port" -j REJECT --reject-with tcp-reset 2>/dev/null || true
+  netfilter-persistent save 2>/dev/null || iptables-save > /etc/iptables/rules.v4
+  echo -e "${GREEN}Purged all DOCKER-USER rules for port $port${NC}"
+  remaining=$(iptables -L DOCKER-USER -n 2>/dev/null | grep -c "dpt:$port" || true)
+  if (( remaining > 0 )); then
+    echo -e "${YELLOW}Warning: $remaining rule(s) still present for port $port:${NC}"
+    iptables -L DOCKER-USER -n 2>/dev/null | grep "dpt:$port"
+  fi
+}
+
+# --purge-port mode
+if [[ -n "$PURGE_PORT" ]]; then
+  purge_port_rules "$PURGE_PORT"
+  exit 0
+fi
+
 # --allow-ip mode
 if [[ -n "$ALLOW_IP" ]]; then
   validate_ip "$ALLOW_IP"
@@ -155,8 +206,9 @@ if [[ ${#REPOS[@]} -eq 0 ]]; then
   echo ""
   echo "Manage existing:"
   echo "  $0 --add-repo new-project"
-  echo "  $0 --allow-ip 1.2.3.4"
-  echo "  $0 --remove-ip 1.2.3.4"
+  echo "  $0 --allow-ip 1.2.3.4    # single IPv4, no CIDR"
+  echo "  $0 --remove-ip 1.2.3.4   # single IPv4, no CIDR"
+  echo "  $0 --purge-port 3306     # drop all rules for a port (decommission)"
   exit 1
 fi
 

--- a/scripts/dolt/setup-remote.sh
+++ b/scripts/dolt/setup-remote.sh
@@ -154,9 +154,11 @@ purge_port_rules() {
     DEBIAN_FRONTEND=noninteractive apt-get install -y iptables-persistent
   fi
   echo "Purging DOCKER-USER rules for port $port..."
-  # Drop all ALLOW rules (any source) - iterate by re-querying to handle multi-IP
-  while iptables -S DOCKER-USER 2>/dev/null | grep -q "dport $port .* -j ACCEPT"; do
-    rule=$(iptables -S DOCKER-USER 2>/dev/null | grep "dport $port .* -j ACCEPT" | head -1 | sed 's/^-A /-D /')
+  # Drop all ALLOW rules (any source) - iterate by re-querying to handle multi-IP.
+  # Pattern matches `iptables -S` output: ` --dport PORT ... -j ACCEPT` at line end
+  # (no required space before -j; iptables may format with or without intermediate args).
+  while iptables -S DOCKER-USER 2>/dev/null | grep -qE " --dport ${port} .*-j ACCEPT$"; do
+    rule=$(iptables -S DOCKER-USER 2>/dev/null | grep -E " --dport ${port} .*-j ACCEPT$" | head -1 | sed 's/^-A /-D /')
     [[ -z "$rule" ]] && break
     eval "iptables $rule" 2>/dev/null || break
   done


### PR DESCRIPTION
Closes lets-nplri.

## Summary

Three concerns shipped on one branch (user-explicit consolidation):

1. **beads-web port 9090 → 3008** to avoid Prometheus collision; matches upstream binary's native default.
2. **scripts/beads-ui/ and scripts/beads/ moved to scripts/deprecated/** with VPS cleanup runbooks. beads-ui (Node.js dashboard, 9080) is superseded by beads-web (Rust binary, 3008). Legacy beads/setup-beads-remote.sh push/pull mode is superseded by Direct SQL.
3. **New scripts/dolt/backup-remote.sh** for ad-hoc operator-initiated Dolt snapshots before risky operations.

## Changes (6 commits)

- `7de2831` fix(lets-nplri): beads-web port 9090→3008 + Dockerfile heredoc
- `082a6d7` chore(lets-nplri): Move beads-ui and beads to scripts/deprecated/
- `999066d` feat(lets-nplri): Add scripts/dolt/backup-remote.sh + iptables hardening
- `5882748` fix(lets-nplri): Migrating Port runbook order (redeploy first, purge after)
- `3259e78` fix(lets-nplri): purge_port_rules regex matches iptables -S output
- `82fad02` docs(lets-nplri): beads-web README - upgrade flow + harmless warnings + ops idioms

## Notable bug fixes

- **Dockerfile heredoc was unintentionally host-substituted.** The `<<DOCKERFILE` (unquoted) form let bash expand `${PORT:-9090}` at script-render time. Healthcheck baked literal port. Anyone deploying with `--port` other than the default got permanently unhealthy containers. Fixed by quoting the heredoc.
- **purge_port_rules regex did not match.** Pattern required a space before `-j` that doesn't exist in `iptables -S` output. Loop never deleted ALLOW rules; only REJECT was removed (separate code path). Discovered during phase 2 migration on proxy-master.

## iptables harmonization

All three setup-remote.sh scripts (dolt, beads-web, deprecated/beads-ui) now share:

- Identical `validate_ip()` - single IPv4 only, no CIDR/masks, octet range check
- New `--purge-port PORT` helper - drops ALL ALLOW + REJECT (v4 + v6) for a port (decommission)
- `umask 077` at script top - tarball + .env get safe perms during creation window

Migration runbooks simplified from 4-7 ssh commands to 2 thanks to `--purge-port`.

## Verified live on proxy-master

- Phase 1: binary upgrade v0.9.3 → v0.11.0 via update-remote.sh (no port change)
- Phase 2: port migration 9090 → 3008 via Order B (redeploy first, then purge)
- Container: Up (healthy) on 3008, 3 ALLOW + REJECT firewall, HTTP 200
- 9090: not listening, no firewall rules
- Backups: 2 tarballs in /opt/dolt-remote/backups/ (chmod 600)

## Test plan

- [x] bash -n on all 5 scripts: clean
- [x] validate_ip rejects CIDR (`1.2.3.4/24`) with new uniform error message
- [x] --purge-port works end-to-end on proxy-master (verified with test rule on port 65501)
- [x] Phase 1 binary upgrade verified: container healthy, 2 projects preserved, SQLite migration v3 applied
- [x] Phase 2 port migration verified: Order B safe, no security window, downtime ~30-60s

## Stats

12 files, +602/-83

Generated with LETS plugin