### PR TITLE
chore: bd config tweaks - disable backup, fix export warnings

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -57,8 +57,15 @@
 
 no-git-ops: true
 
+# JSONL auto-export: bd writes .beads/issues.jsonl after each Dolt write.
+#  export:
+#   git-add: false  (set below) - .beads/ is gitignored, so bd's default `git add issues.jsonl` would fail and warn.
+#   auto: false     (commented)  - if you ever want to disable export entirely (no JSONL refresh), uncomment this line.
+# We keep export.auto at its default (true) so external tools (beads-web
+# JSONL fallback, viewers) can read the file without a SQL connection.
 export:
-  auto: false
+  git-add: false
+  # auto: false
 
 # Disable Dolt-mode auto-backup (calls CALL DOLT_BACKUP('add', ...) which
 # requires admin SQL grants our per-database user doesn't have).

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -57,4 +57,11 @@
 
 no-git-ops: true
 
-export.auto: false
+export:
+  auto: false
+
+# Disable Dolt-mode auto-backup (calls CALL DOLT_BACKUP('add', ...) which
+# requires admin SQL grants our per-database user doesn't have).
+# Backups are handled by VPS-level snapshots + scripts/dolt/backup-remote.sh.
+backup:
+  enabled: false


### PR DESCRIPTION
Follow-up to #52. Two related fixes in `.beads/config.yaml`.

## What

```yaml
export:
  git-add: false
  # auto: false      # opt-in if you ever want to disable JSONL refresh

backup:
  enabled: false     # disable Dolt-mode auto-backup (no admin SQL grants)
```

## Why

### `backup.enabled: false`
bd 1.0.2 auto-tries `CALL DOLT_BACKUP('add', 'backup_export', ...)` on every command. Our per-database SQL user lacks BACKUP admin grants, so this fails with `Error 1105 (HY000): command denied` - visible warning spam in stderr after every bd invocation.

bd's auto-backup is redundant for our setup:
- VPS-level snapshots (daily + weekly, host-level)
- `scripts/dolt/backup-remote.sh` (ad-hoc, application-aware Dolt snapshots, added in #52)

### `export.git-add: false` + revert of `export.auto: false`
External tools (beads-web JSONL fallback, viewers) read `.beads/issues.jsonl` to mirror state without a SQL connection - keeping it in sync after each write is desired.

The previous `export.auto: false` (commit `65595c7`) was added because of a noisy `auto-export: git add failed` warning. Root cause: `.beads/` is gitignored, so bd's default `git add issues.jsonl` after each export fails. Fix at the right level: keep auto-export ON (default), disable just the git-add step.

## Verified empirically

- `backup.enabled` removed → warning returns; re-added → suppressed
- `export.auto` commented out → `bd config get export.auto` returns `true` (default)
- After write past 60s throttle → `.beads/issues.jsonl` mtime updates, no warnings
- `export.git-add: false` → no `git add failed` warning

## Stats

1 file, +18/-1