### PR TITLE
chore: gitignore /dist/ (lets-cupy1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ dolt-monitor.*
 /docs-local/
 /scripts/deprecated/
 
+# goreleaser output (created by `goreleaser release --snapshot` / tag-driven CI release)
+/dist/
+
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
 issues.jsonl


### PR DESCRIPTION
## Summary

Tiny hotfix discovered during local goreleaser snapshot validation (Step 11.1a of lets-hdrdr.4 release ceremony):

After lets-hdrdr.4 shipped goreleaser support, every `goreleaser release --snapshot` run creates a `dist/` directory at repo root with ~15 MB of platform binaries + archives + checksums. The `--clean` flag auto-cleans on next run, but a one-shot snapshot leaves `dist/` untracked in `git status` — a single accidental `git add -A && git commit` could include all binaries.

Adds `/dist/` to `.gitignore` alongside the existing `/scripts/deprecated/` entry.

## Test plan

- [ ] CI: `verify-versions.yml` passes (no version changes)
- [ ] Local: `goreleaser release --snapshot --clean --skip=publish,sign` creates `dist/` → `git status` shows clean tree (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)