### PR TITLE
chore: release v0.5.0-rc.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lets",
       "source": "./plugins/lets",
       "description": "Development workflow with session management, code review, and task tracking",
-      "version": "0.5.0"
+      "version": "0.5.0-rc.1"
     }
   ]
 }

--- a/plugins/lets/.claude-plugin/plugin.json
+++ b/plugins/lets/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.5.0",
+  "version": "0.5.0-rc.1",
   "author": {
     "name": "restarter",
     "url": "https://github.com/restarter"

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.5.0
+version: 0.5.0-rc.1
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->


### PR DESCRIPTION
## Summary

Cut **v0.5.0-rc.1 prerelease** as the first real-tag validation of the release pipeline shipped in lets-hdrdr.4.

This bumps source-tree version to `0.5.0-rc.1` across 3 files (plugin.json, marketplace.json, lets-rules.md frontmatter). **CHANGELOG.md is intentionally NOT touched** — per Key Decision 9 in the release tooling plan, prereleases are validation snapshots; the full release entry is reserved for the stable v0.5.0 tag. release.yml will fall back to `[Unreleased]` for the GH Release page notes.

After this PR merges, maintainer runs `make release-tag VERSION=0.5.0-rc.1` to push the tag and trigger goreleaser via `release.yml`.

## What this validates (live-only risks not catchable by snapshot)

- release.yml triggers on `push: tags: ['v*']`
- `permissions: contents: write` actually grants `gh release create` rights
- goreleaser-action@v6 runtime behavior matches local goreleaser CLI
- `prerelease: auto` correctly auto-flags `-rc.1` semver suffix
- Real-tag awk extract from `[Unreleased]` (since `[0.5.0-rc.1]` section doesn't exist)

Local goreleaser snapshot already validated config + cross-build matrix (5 platforms, 2.6-2.9 MB archives, valid Mach-O/ELF/PE32+ binaries, sha256 checksums all match).

## Test plan

- [ ] CI: `verify-versions.yml` passes on this PR
- [ ] After merge: `make release-tag VERSION=0.5.0-rc.1` from main
- [ ] `release.yml` runs guard + goreleaser jobs successfully (~5 min)
- [ ] GH Releases gets `v0.5.0-rc.1` entry, marked as **prerelease**
- [ ] 5 archives + `lets_0.5.0-rc.1_checksums.txt` uploaded
- [ ] Release notes match [Unreleased] CHANGELOG content
- [ ] Downloaded darwin/arm64 binary: `lets version` → `0.5.0-rc.1`

Beads: lets-y5r53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)