### PR TITLE
chore: bump GHA actions for Node.js 24 (lets-iynks)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
     name: Verify tag coherence
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Verify source-tree + tag
@@ -33,12 +33,12 @@ jobs:
     needs: guard
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'cli/go.mod'
           cache-dependency-path: 'cli/go.sum'
@@ -70,7 +70,7 @@ jobs:
           cat /tmp/release-notes.md
 
       - name: Run goreleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
           version: '~> v2'

--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0   # need full history for git describe (--against-tag check)
 


### PR DESCRIPTION
## Summary

Discovered during v0.5.0-rc.1 release.yml run: GitHub Actions warned that all 3 of our actions are running on deprecated Node.js 20.

**Timeline (per [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)):**
- **2026-06-02** (~3 weeks from now) — Actions force-switch to Node.js 24
- **2026-09-16** — Node.js 20 removed from runners

Cleaning this up before v0.5.0 final cut so the first stable release run has zero warnings.

## Bumps

| Action | From | To | Where |
|---|---|---|---|
| actions/checkout | v4 | v6 (latest 6.0.2) | both workflows (3 refs) |
| actions/setup-go | v5 | v6 (latest 6.4.0) | release.yml |
| goreleaser/goreleaser-action | v6 | v7 (latest 7.2.1) | release.yml |

All bumped to Node-24-supporting versions. No breaking config changes.

## Test plan

- [ ] CI: `verify-versions.yml` runs on this PR using updated `actions/checkout@v6` — passes WITHOUT Node 20 warning
- [ ] After merge: v0.5.0 stable cut → `release.yml` run with all v6/v7 actions has clean output (no Node deprecation warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)