### PR TITLE
chore: release v0.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lets",
       "source": "./plugins/lets",
       "description": "Development workflow with session management, code review, and task tracking",
-      "version": "0.5.0-rc.1"
+      "version": "0.5.0"
     }
   ]
 }

--- a/.claude/rules/lets-rules.md
+++ b/.claude/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.5.1
+version: 0.5.0
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-10
+
 ### Added (Go CLI port - lets-7vtaw, Phases 1-4b)
 - Go CLI binary `lets` with subcommands: `lets version`, `lets hook session-start`, `lets hook precompact`, `lets statusline`, `lets init`. Cross-compiles for darwin/arm64, linux/amd64, windows/amd64. Module path: `github.com/restarter/lets-workflow/cli`
 - Monorepo layout: plugin payload moved to `plugins/lets/` subdir; new `cli/` parallel directory; root `Makefile` for `make build/test/vet/lint/fmt/install`
@@ -263,7 +265,8 @@ Initial release with expert agents team.
 - SessionStart hook injecting workflow rules
 - Plugin structure: commands, agents, hooks
 
-[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/restarter/lets-workflow/compare/v0.3.0...v0.5.0
 [0.3.1]: https://github.com/restarter/lets-workflow/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/restarter/lets-workflow/compare/v0.2.4...v0.3.0
 [0.2.4]: https://github.com/restarter/lets-workflow/compare/v0.2.3...v0.2.4

--- a/plugins/lets/.claude-plugin/plugin.json
+++ b/plugins/lets/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.5.0-rc.1",
+  "version": "0.5.0",
   "author": {
     "name": "restarter",
     "url": "https://github.com/restarter"

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.5.0-rc.1
+version: 0.5.0
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->


### PR DESCRIPTION
## Summary

**First stable release** using the new tag-driven goreleaser pipeline shipped in lets-hdrdr.4.

After v0.5.0-rc.1 prerelease validated the full pipeline end-to-end (release.yml, goreleaser, prerelease auto-detection, ldflags injection, downloaded binary smoke-test), this PR cuts v0.5.0 stable.

## Diff (2 commits)

1. **`fix(lets-jfu8d): .claude/rules/lets-rules.md frontmatter — sync installed copy`** — installed copy was at stale v0.5.1 (development placeholder, never released); set to 0.5.0 directly to match upcoming release.

2. **`chore: release v0.5.0`** (via `make bump VERSION=0.5.0`):
   - `plugin.json::version` → 0.5.0
   - `marketplace.json::plugins[].version` → 0.5.0
   - `lets-rules.md` frontmatter → 0.5.0
   - `CHANGELOG.md`: `[Unreleased]` promoted to `[0.5.0] - 2026-05-10` with full accumulated content (Go CLI port, lets-hdrdr.2 fixes, /lets:init Go-native bridge, release tooling, etc.)
   - Bottom link `[0.5.0]: compare/v0.3.0...v0.5.0` — PREV_TAG filter correctly excludes v0.5.0-rc.1 prerelease, compares to last STABLE tag

## What lands when this merges

After merge, maintainer runs `make release-tag VERSION=0.5.0`:
1. `release.yml` triggered (with new Node 24 actions from PR #58 — clean run, no warnings)
2. `goreleaser` builds 5 platform binaries, archives, checksums
3. GH Releases gets `v0.5.0` entry (NOT prerelease — no `-` suffix)
4. Notes pulled from `[0.5.0]` CHANGELOG section (full release entry)

## Test plan

- [ ] CI: `verify-versions.yml` passes on this PR (Node 24 actions, no warnings)
- [ ] After merge: `make release-tag VERSION=0.5.0`
- [ ] `release.yml` runs successfully — guard ✓ + goreleaser ✓
- [ ] GH Releases `v0.5.0` page exists, **NOT marked prerelease**
- [ ] 5 archives + `lets_0.5.0_checksums.txt` uploaded
- [ ] Release notes contain full `[0.5.0]` CHANGELOG section
- [ ] Downloaded darwin/arm64 binary on Mac M1: `lets version` → `0.5.0`

Beads: lets-jfu8d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)