### PR TITLE
feat: Install scope guidance for marketplace adoption

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,8 +1,4 @@
 {
-  "enabledPlugins": {
-    "plugin-dev@claude-plugins-official": true,
-    "skill-creator@claude-plugins-official": true
-  },
   "hooks": {
     "PreCompact": [
       {
@@ -28,7 +24,12 @@
     ]
   },
   "statusLine": {
-    "command": "lets statusline",
-    "type": "command"
+    "type": "command",
+    "command": "lets statusline"
+  },
+  "enabledPlugins": {
+    "plugin-dev@claude-plugins-official": true,
+    "skill-creator@claude-plugins-official": true,
+    "lets@lets-workflow": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+- README "Recommended scope" note in Install section: project scope is preferred for team-shared repos so teammates inherit `lets` without re-install (lets-i5ayk)
+- `/lets:init` Step 1b: detect plugin install scope from `~/.claude/plugins/installed_plugins.json`; one-time informational notice when scope is `user`, suggesting re-install at project scope. No notice for `project` (best case), `local` (deliberate choice), or `unknown` (dev mode / missing file) (lets-i5ayk)
+
 ## [0.5.0] - 2026-05-10
 
 ### Added (Go CLI port - lets-7vtaw, Phases 1-4b)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Then in Claude Code:
 /plugin install lets
 ```
 
+**Recommended scope:** when Claude Code asks "Install for...", pick **"Install for all collaborators on this repository" (project scope)**. This commits the choice to `.claude/settings.json` so teammates inherit `lets` without re-installing. Use user scope only for personal/throwaway projects; local scope is rarely useful.
+
 ### Setup
 
 ```bash

--- a/plugins/lets/commands/init.md
+++ b/plugins/lets/commands/init.md
@@ -50,6 +50,34 @@ Then proceed with first-time path (ENV_ABSENT, BEADS_ABSENT both true for fresh 
 
 If "Cancel" → STOP. NO LETS box.
 
+### 1b. Plugin install scope check
+
+```bash
+PLUGINS_FILE="$HOME/.claude/plugins/installed_plugins.json"
+SCOPE=""
+if [ -f "$PLUGINS_FILE" ] && command -v python3 >/dev/null 2>&1; then
+  SCOPE=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$PLUGINS_FILE'))
+    entries = d.get('plugins', {}).get('lets@lets-workflow', [])
+    print(entries[0].get('scope', '') if entries else '')
+except Exception:
+    pass
+" 2>/dev/null)
+fi
+echo "SCOPE=${SCOPE:-unknown}"
+```
+
+Branch on `$SCOPE`:
+- `project` → no notice. Best case.
+- `user` → surface a one-time notice (one short line), then continue:
+  > ℹ️ Plugin installed at **user scope** (only you). For team adoption, re-install at project scope: `/plugin uninstall lets` → `/plugin install lets` → pick "Install for all collaborators on this repository".
+- `local` → no notice. User picked deliberately ("this repo only for me").
+- `unknown` (empty / file missing / dev `--plugin-dir` mode) → no notice.
+
+The notice is informational, not a blocker. Continue with Step 2/3 regardless.
+
 ## Step 2: First-time path
 
 ### 2a. Detect language


### PR DESCRIPTION
## Summary

Final stabilization piece for marketplace release (lets-i5ayk epic). Adds guidance for picking the right install scope, plus a one-time notice in `/lets:init` when the user installed at user scope (which doesn't propagate to teammates).

## Changes

- **README.md** — "Recommended scope" note in Install section: project scope is preferred for team-shared repos so teammates inherit `lets` automatically
- **plugins/lets/commands/init.md** — Step 1b: detect plugin install scope from `~/.claude/plugins/installed_plugins.json`; one-time informational notice when scope is `user`. No notice for `project` (best case), `local` (deliberate), or `unknown` (dev mode / missing file)
- **CHANGELOG.md** — Unreleased entry
- **.claude/settings.json** — formatting (Claude Code reordered `statusLine` fields and added `lets@lets-workflow` to `enabledPlugins` after marketplace install)

## Verified end-to-end this session

Fresh Claude session in `/Users/umbo/projects/lets-workflow`:
- ✅ SessionStart hook fires: `## LETS Config` injected with all 5 keys (LETS_PROJECT_ROOT/LANGUAGE/MERGE_BRANCH/PR_FLOW/TRACKER)
- ✅ Drift check correctly silent (plugin and `.claude/rules/lets-rules.md` both at 0.5.0)
- ✅ Manual `lets hook session-start` matches automatic invocation bit-for-bit (no stdout filtering by Claude Code)
- ✅ `/lets:status` and `/lets:done` work from marketplace install

## Known limitation (won't fix)

If user runs `/plugin install lets` AFTER session start, SessionStart hook can't fire for that session (event already past). Workaround: restart Claude. Tracking mechanisms considered (hook-fire timestamp comparison, per-session marker file, statusline indicator) all rejected as too brittle for the value. The existing restart hint in `/lets:init` covers the normal init flow.

## Task

Closes epic lets-i5ayk · Prepare plugin for marketplace release

---
Generated with LETS plugin