### PR TITLE
Plugin command-surface batch (lets-v1rm1 + lets-sjtiy.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,15 @@
 - **Local Config explainer** embedded in SessionStart hook output (via `//go:embed local_config_explainer.md`). Values + their per-key usage docs (semantics, bash-block rule for `LETS_PROJECT_ROOT`, fallbacks, prompt-injection defense) now travel together. Hook output grew 155 B → ~2 KB, still well under 10 K cap (lets-q9bx7)
 - New `Boundaries` bullet: never edit installed `lets-*` rules files in `.claude/rules/`. Surfaces installed-copy doctrine at runtime (was previously only in CLAUDE.md + bd remember) (lets-q9bx7, lets-0okn8)
 - 2 new bullets in `Architecture Mindset`: "Smallest change that solves the problem" (anti-scope-creep) and "Plan for breaking changes" (migration / back-compat discipline) (lets-kzne5 partial)
-- `Phase Detection & LETS Boxes`: explicit exception "internal invocation = no box" — when one `/lets:*` command invokes another programmatically (e.g. `/lets:review --json` from `/lets:pr`), inner command's LETS box is waived to avoid duplicate next-step suggestions in one response (lets-t6c27)
+- `Phase Detection & LETS Boxes`: explicit exception "internal invocation = no box" — when one `/lets:*` command invokes another programmatically (e.g. `/lets:review --json` from `/lets:github-pr`), inner command's LETS box is waived to avoid duplicate next-step suggestions in one response (lets-t6c27)
 - CLAUDE.md doctrine: `.claude/rules/lets-rules.md` (installed copy) is never edited directly — only the canonical source `plugins/lets/rules/lets-rules.md`, refreshed via `/lets:init`. Dogfoods drift detection live (lets-0okn8)
 - `.claude/rules/git.md` updated with scope (task-id) format `feat(lets-sds): subject`, examples for tracked/ad-hoc commits, body-WHY discipline, and `/lets:commit` skill pointer (lets-vlw2k)
+- `/lets:plan --fast` flag — orchestrator-only planning that skips the three subagent-dispatch phases (Step 4 explorers, Step 6 architects, Step 7 experts) and replaces them with in-session work (read files yourself, draft approaches inline, self-evaluate risks). Clarifying questions, checkpoints, discussion, plan format, and beads recording are unchanged; the Plan Ready output records which mode was used. Combinable with a task-id (lets-lq1ud)
+- `/lets:check` parameter parity with `/lets:review` — accepts `<PR-url-or-number>`, `--local` (explicit), `--file <path>`, and `--json` in addition to `--staged`/`--last-commit`/`--plan`; `argument-hint` is byte-identical to `/lets:review`. PR mode warns when the PR is large (suggests full `/lets:review`); `--file` mode reviews full file content; `--json` output mirrors `/lets:review --json` (same `verdict`/`tier`/`findings[]` shape, `agent: "check"` + per-finding `lens`, `summary` object). No subagent dispatch in any mode — that's the only thing that stays inline vs `/lets:review`. End-of-run LETS box offers the matching `/lets:review --<flag>` upgrade path (lets-qadj0)
+- `/lets:done` Step 5 — CHANGELOG update step: when `CHANGELOG.md` exists at the project root and the task touched user-visible files, offers (AskUserQuestion: Add / Edit / Skip) to add a `[Unreleased]` entry drafted from the task title + commits and commit it via `/lets:commit` so it lands in the same PR; skips silently and says so when there's no `CHANGELOG.md` (lets-v1rm1.1)
+- `/lets:start` Step 7 — suggests `/rename {slug}` after a task is claimed so the statusline reflects the active task. Presented as a paste-ready hint (`/rename` is user-invoked; the assistant can't run it), not a gate (lets-gzsho)
+- **Plan-visibility gate** in `lets-rules.md` AUTO MODE section — present the plan (per task/file, what changes, in what order) before any edits, even in AUTO MODE; one approval covers a multi-task batch. "Execute immediately" now means "run the next step of an approved plan", not "skip showing the plan"; "let's think about how to do X" / "проаналізуй" is a request for a plan, not a green light to edit. Plus a matching Soft stop line (lets-sjtiy.1)
+- CLAUDE.md "Command Output Requirements": "Which shortcuts to offer" guidance for LETS boxes (most-likely next step + lighter/faster alternative where one exists + escape hatch; same-width-within-a-file rule made explicit) and a Command Checklist line for it (lets-ne36e)
 
 ### Changed
 - **Discovery Logging** rewritten: orchestrator now proactively suggests `/lets:note` (approval gate) instead of autonomous `bd comments add`. Aligned with broader "never act without user approval" principle. Trigger list expanded with user-driven moments (accepted decisions, shared facts, external context). Removed artificial length cap on recorded content — future recovery beats brevity (lets-0okn8)
@@ -22,11 +28,17 @@
 - `Task References` examples trimmed from 5 to 3 (Flowing text + Report rows + Bad) — redundant patterns removed (lets-t6c27)
 - `Beads Task Creation`: deferred to `create-task` skill (was duplicating skill's required-fields contract) (lets-t6c27)
 - `Architecture Mindset` bullets reworded with bold keywords for scanability (lets-kzne5 partial)
+- **`/lets:pr` renamed to `/lets:github-pr`** — the PR review lifecycle command supports GitHub only (via `gh` CLI); Bitbucket and local-merge PR flows are not implemented (those finish tasks via `/lets:done`). Command file `pr.md` → `github-pr.md`; all `/lets:pr` references updated across commands, skills, `lets-rules.md`, CLAUDE.md, README; H1 and intro now state "GitHub only" (lets-v1rm1.2)
+- LETS-box audit across all 17 command files — box widths now consistent within each file (brainstorm/check/execute/github-pr/review/team/worktree had mixed widths; worktree boxes had `/lets:worktree` commands touching the right border with no padding); added the lighter `/lets:check` alternative wherever `/lets:review` was offered alone (execute, team, review); `/lets:plan` Plan Ready box gains `Check plan? /lets:check --plan` (lets-ne36e)
 
 ### Removed
 - **Local Config** section from `lets-rules.md` — content moved into hook output explainer (lets-q9bx7)
 - **Key Principles** section from `lets-rules.md` — all 6 points were restatements of earlier sections (Task Selection MANDATORY, Task Size Assessment, Discovery Logging, Git Conventions, LETS Box rule). No new facts (lets-t6c27)
 - **Git Conventions** section from `lets-rules.md` — commit format / subject length are project preference (teams differ), `git status` ritual is workflow opinion covered by `/lets:commit` skill, `Task:` footer is enforced programmatically by skill. Project-specific git rules live in user-owned `.claude/rules/git.md` (lets-kzne5 partial)
+- spurious `> **IMPORTANT:**` deferred-tool callout from `commands/check.md` — the command invokes no `AskUserQuestion`; the brief now notes "no AskUserQuestion gates" instead (lets-qadj0)
+
+### Fixed
+- `bd comments list <id> [--limit N]` corrected to `bd comments <id>` in `/lets:start`, `/lets:note`, `/lets:team`, and the `take-task` skill — `bd comments` has no `list` subcommand or `--limit` flag (default already lists all), and the bad syntax made `/lets:start <task-id>` fail against bd v1.0.2. Those flows now also instruct reading the FULL task description and ALL comments, not a truncated slice (lets-8ptef)
 
 ### Closed tasks
 - lets-0okn8 — Enhance rules injection (Discovery Logging + Context Window + installed-copy doctrine)
@@ -35,6 +47,16 @@
 - lets-eb8zc — Proactive pattern recognition
 - lets-t6c27 — Context window / rules audit pass
 - lets-vlw2k — AUTO MODE stop conditions
+- lets-8ptef — `bd comments` syntax bug in 4 plugin files
+- lets-gzsho — Auto-rename session on `/lets:start` (as a paste-ready suggestion)
+- lets-v1rm1.1 — CHANGELOG update step in `/lets:done`
+- lets-v1rm1.2 — Rename `/lets:pr` → `/lets:github-pr` (GitHub-only flow)
+- lets-qadj0 — Align `/lets:check` parameter surface with `/lets:review`
+- lets-lq1ud — `/lets:plan --fast` flag
+- lets-ne36e — LETS-box audit + shortcut-selection guidance
+- lets-sjtiy.1 — Plan-visibility gate in AUTO MODE rules
+- lets-afwa4 — Refine ultrathink (already shipped in PR #24; closed as superseded)
+- lets-ae0wt — Standardize branch parsing comments (resolved by `detect-task` skill extraction)
 
 ### Tracked follow-ups
 - lets-93mbk [P0] — Route commands through internal task skills (create-task, take-task, detect-task)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,6 +233,7 @@ Every lets:* command MUST end with branded LETS box:
 - Lines: `│  ` + content + padding + ` │`
 - Footer: `└─` + padding with `─` + `┘`
 - Min width: 25 chars
+- **All boxes in one file MUST have the same width** - use the widest box's content as the reference and pad the rest. (Quick check: extract every box, the header/content/footer line lengths must all match per-box and across boxes in the file.)
 
 **Content guidelines:**
 - Short action word + `?` (e.g., "Commit?", "Next?", "Fix?")
@@ -241,9 +242,17 @@ Every lets:* command MUST end with branded LETS box:
 - **No command = no box** - if next step isn't a /lets:* command, just ask in plain text
 - **Internal invocation = no box** - when a command is invoked programmatically by another command (e.g., `/lets:review --json` called by `/lets:github-pr`), the LETS box is waived
 
+**Which shortcuts to offer (pick from these three, in order):**
+1. **Most-likely next step** in the workflow loop - always include. (After `/lets:check` -> `/lets:commit`; after `/lets:commit` -> `/lets:done`; after `/lets:plan` -> `/lets:execute`; etc.)
+2. **A lighter/faster alternative**, if one exists - include when applicable. Pairs: `/lets:check` is the lighter `/lets:review`; `/lets:check --plan` is the lighter `/lets:review --plan`; `/lets:ask` is the lighter `/lets:opinion`. If a box offers the heavy command, offer the light one alongside it (and pass the matching flag - `/lets:review --local` -> also `/lets:check --local`).
+3. **An escape hatch** - `/lets:start` (new task), `/lets:end` (wrap session), or `/lets:status` (where am I). Pure-navigation boxes (e.g. `Start? /lets:start` after `/lets:init`) are *only* an escape hatch and that's fine - don't pad them with irrelevant options.
+
+Don't exceed ~4 lines in a box. If a command genuinely has only one sensible next step, one line is correct.
+
 ### Command Checklist
 
 - [ ] Has LETS box in output section
+- [ ] LETS box shortcuts follow the guidance above (most-likely next step + lighter alternative where one exists + escape hatch); all boxes in the file are the same width
 - [ ] Updates Skill Quick Reference in `plugins/lets/rules/lets-rules.md` (and bump frontmatter `version`)
 - [ ] Updates `/lets:install` Essential Skills / Planning Skills tables
 - [ ] Follows session flow (start -> work -> commit -> done -> end)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ References that resolve via `${CLAUDE_PLUGIN_ROOT}` (e.g. `${CLAUDE_PLUGIN_ROOT}
 
 - **Commands** = user-initiated workflows (sessions, commits, reviews)
 - **Agents** = experts dispatched by commands. `/lets:review`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:brainstorm` dispatch via subagents. `/lets:team` dispatches via Agent Teams (parallel, worktree isolation). `actor` is a meta-agent that loads external personalities (URL or file) and adapts them to LETS modes
-- **Orchestrators** = commands that delegate to other commands. `/lets:pr` orchestrates `/lets:review` for full PR lifecycle
+- **Orchestrators** = commands that delegate to other commands. `/lets:github-pr` orchestrates `/lets:review` for full PR lifecycle
 - **Hooks** = SessionStart + PreCompact inject workflow rules (PreCompact preserves rules across context compaction in long sessions)
 - **Statusline** = `lets statusline` Go subcommand. Project `.claude/settings.json` invokes it directly. `lets init` detects the canonical command via value-match against `"lets statusline"`; foreign user-customized commands are left alone. Legacy bash shim `plugins/lets/scripts/lets/statusline.sh` removed in lets-8ilsl. Byte-equal detection of pre-deletion installs (.lets/statusline.sh) handled via the frozen `cli/internal/initcmd/embedded_statusline_shim.sh` snapshot — `MigrateStatuslineSh` deletes matching legacy shims and triggers `SetStatusLine` to point settings.json at `lets statusline`.
 - **`.env` versioning** — first key `LETS_ENV_VERSION` records which `lets` binary version last regenerated the file. `lets init` regenerates when version mismatches the running binary OR when CLI prefs flags are passed with new values. `RegenerateEnv` (`cli/internal/initcmd/env.go`) is the canonical writer; preserves user values + foreign keys (under `# User-added keys` separator), refreshes header. NOT in `letsconfig.Keys` whitelist (metadata, not user-config) — hook session injection skips it. Reusable for future `/lets:update` (lets-hdrdr.3).
@@ -58,7 +58,7 @@ References that resolve via `${CLAUDE_PLUGIN_ROOT}` (e.g. `${CLAUDE_PLUGIN_ROOT}
 - Agent selection: each command owns its detection/selection logic (different semantics per context). Multi-agent dispatching commands (review, opinion, brainstorm, plan) show selection panel with cost note before launch. Most agents have explicit PLAN mode for plan review.
 - Agents always respond in English. Commands localize output to user's language via LETS Config and Rules.
 - `/lets:review`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:brainstorm` use `subagent_type: "lets:agent-name"` to dispatch agents via Task tool
-- `/lets:pr` orchestrates `/lets:review` (delegates analysis) and handles GitHub posting, follow-up, respond, and approval directly via gh CLI
+- `/lets:github-pr` orchestrates `/lets:review` (delegates analysis) and handles GitHub posting, follow-up, respond, and approval directly via gh CLI
 - `/lets:execute` uses EnterPlanMode for native plan mode execution with user approval gates. No subagents.
 - `/lets:check` reviews inline (no subagent) for speed
 - All analyst agents are read-only with uniform tools: `Read, Grep, Glob, Bash`. No `Edit/Write`. Exception: `agents/implementer.md` adds `Edit/Write` for `/lets:team` parallel implementation in isolated worktrees.
@@ -215,7 +215,7 @@ Update these files:
 | `CLAUDE.md` Key Concepts | If adding a new skill |
 | `README.md` | Agent table, feature descriptions |
 | All `agents/*.md` `## Constraints` sections | If changing the read-only Bash allowlist or constraint wording, sync the identical 1-line text across all 13 analyst agents (verify with `grep -h "You are read-only" agents/*.md \| sort -u` returning exactly one line) |
-| `commands/end.md` + `commands/done.md` `${CLAUDE_SESSION_ID}` references | If changing the session-id capture wording, sync across all occurrences (Step 3 progress comment + Step 5 summary block in `end.md`, Step 6 completion comment in `done.md`). Verify with `grep -n "CLAUDE_SESSION_ID" commands/` |
+| `commands/end.md` + `commands/done.md` `${CLAUDE_SESSION_ID}` references | If changing the session-id capture wording, sync across all occurrences (Step 3 progress comment + Step 5 summary block in `end.md`, Step 7 completion comment in `done.md`). Verify with `grep -n "CLAUDE_SESSION_ID" commands/` |
 | `cli/internal/cli/<name>.go` + register in `cli/internal/cli/root.go` | If adding a Go subcommand. Add `<name>_test.go` (`package cli_test`). Use `cmd.OutOrStdout()`. Domain logic goes in `cli/internal/<name>/` (see `initcmd/`, `sessionstart/`, `statusline/`, `frontmatter/` for patterns). Update `cli/README.md` "Adding a subcommand" recipe if pattern changes. |
 
 ### Command Output Requirements
@@ -239,7 +239,7 @@ Every lets:* command MUST end with branded LETS box:
 - **ONLY `/lets:*` commands** - never raw commands like `bd sync`, `bd update`
 - **Exception:** `git push` allowed after `/lets:done` or `/lets:end`
 - **No command = no box** - if next step isn't a /lets:* command, just ask in plain text
-- **Internal invocation = no box** - when a command is invoked programmatically by another command (e.g., `/lets:review --json` called by `/lets:pr`), the LETS box is waived
+- **Internal invocation = no box** - when a command is invoked programmatically by another command (e.g., `/lets:review --json` called by `/lets:github-pr`), the LETS box is waived
 
 ### Command Checklist
 

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Then start working:
 |---------|-------------|
 | `/lets:check` | Quick inline sanity check (~30s, 6-perspective review) |
 | `/lets:review` | Full code review with dynamic agent selection (~2-3 min) |
-| `/lets:pr` | PR review lifecycle - analyze, discuss, post inline, follow-up, approve |
+| `/lets:github-pr` | GitHub PR review lifecycle - analyze, discuss, post inline, follow-up, approve |
 | `/lets:opinion` | Technical decision analysis (dynamic expert agents in parallel) |
 | `/lets:ask` | Quick expert consultation (single agent) |
 
@@ -206,23 +206,23 @@ Three levels of review, from 30-second sanity check to full PR lifecycle:
 |------|---------|------|-------------|
 | Quick pre-commit check | `/lets:check` | ~30s | Inline 6-lens review: bugs, security, performance, quality, compliance, docs |
 | Full code review | `/lets:review` | ~2-3 min | Dynamic agent selection - only relevant experts for your changes |
-| Full PR lifecycle | `/lets:pr <PR>` | Interactive | Analyze, discuss, post inline comments, follow up on fixes, approve |
+| Full PR lifecycle (GitHub) | `/lets:github-pr <PR>` | Interactive | Analyze, discuss, post inline comments, follow up on fixes, approve |
 
-### PR Review Lifecycle (`/lets:pr`)
+### GitHub PR Review Lifecycle (`/lets:github-pr`)
 
-This is where LETS shines. Instead of reviewing PRs in a browser, you do it from the terminal with expert agents:
+This is where LETS shines. Instead of reviewing PRs in a browser, you do it from the terminal with expert agents. GitHub only — Bitbucket/local flows aren't implemented (those finish tasks via `/lets:done`):
 
 ```
-/lets:pr https://github.com/owner/repo/pull/42
+/lets:github-pr https://github.com/owner/repo/pull/42
 ```
 
 1. **Analyze** - agents review the PR based on what actually changed (security agent for auth code, database for migrations, etc.)
 2. **Discuss** - you see each finding with code context, decide what to post: inline comment, summary, or drop
 3. **Post** - batch-posts inline comments to the exact lines on GitHub, with a review summary
-4. **Follow up** - after the author pushes fixes, `/lets:pr --follow-up` checks each finding: fixed, not fixed, or needs discussion
-5. **Approve** - `/lets:pr --approve` when ready, or request changes
+4. **Follow up** - after the author pushes fixes, `/lets:github-pr --follow-up` checks each finding: fixed, not fixed, or needs discussion
+5. **Approve** - `/lets:github-pr --approve` when ready, or request changes
 
-Authors can respond with `/lets:pr --respond` - triage comments, auto-fix mechanical issues, post replies.
+Authors can respond with `/lets:github-pr --respond` - triage comments, auto-fix mechanical issues, post replies.
 
 ### Dynamic Agent Selection
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Then start working:
 | Command | Description |
 |---------|-------------|
 | `/lets:brainstorm` | Interactive ideation - backlog review, idea exploration, quick brainstorm, cleanup |
-| `/lets:plan` | Structured planning - explore codebase, design architecture, write plan |
+| `/lets:plan` | Structured planning - explore codebase, design architecture, write plan (`--fast` = orchestrator-only, no subagents) |
 | `/lets:execute` | Execute plan from `/lets:plan` via native plan mode |
 | `/lets:team` | Parallel implementation with Agent Teams |
 | `/lets:worktree` | Create/manage worktrees for parallel sessions |
@@ -244,7 +244,7 @@ For plan reviews, agents are selected by signals in the plan content (mentions o
 - *Quick brainstorm* - fast ideation on a topic
 - *Cleanup* - find stale tasks, broken dependencies, forgotten work
 
-**Plan** (`/lets:plan`) - codebase exploration with dynamically-scaled explorer agents, then architecture design with expert evaluation. Small project? One explorer. Large monorepo? Up to 10, each mapping a different area.
+**Plan** (`/lets:plan`) - codebase exploration with dynamically-scaled explorer agents, then architecture design with expert evaluation. Small project? One explorer. Large monorepo? Up to 10, each mapping a different area. Want a quick talk-through instead? `/lets:plan --fast` skips the subagent phases and plans collaboratively in-session.
 
 **Execute** (`/lets:execute`) - implements the plan step by step in native plan mode. You approve each step before Claude proceeds. No surprises.
 

--- a/plugins/lets/commands/brainstorm.md
+++ b/plugins/lets/commands/brainstorm.md
@@ -684,20 +684,20 @@ bd comments add <task-id> "Cleanup: closed {N}, reprioritized {M}, labeled {L}, 
 ### After Review Backlog / Explore Idea modes:
 
 ```
-┌─ LETS ──────────────────────────────────┐
-│  Plan a task?  /lets:plan               │
-│  Start work?   /lets:start              │
-└─────────────────────────────────────────┘
+┌─ LETS ─────────────────────────┐
+│  Plan a task?  /lets:plan      │
+│  Start work?   /lets:start     │
+└────────────────────────────────┘
 ```
 
 ### After Quick Brainstorm:
 
 ```
-┌─ LETS ──────────────────────────────────┐
-│  Go deeper?  /lets:brainstorm           │
-│  Plan?       /lets:plan                 │
-│  Start?      /lets:start                │
-└─────────────────────────────────────────┘
+┌─ LETS ─────────────────────────┐
+│  Go deeper?  /lets:brainstorm  │
+│  Plan?       /lets:plan        │
+│  Start?      /lets:start       │
+└────────────────────────────────┘
 ```
 
 ### After Cleanup:

--- a/plugins/lets/commands/check.md
+++ b/plugins/lets/commands/check.md
@@ -74,10 +74,10 @@ Read the plan and review with 5 lenses (same confidence filter):
 Output same format as code check, then:
 
 ```
-┌─ LETS ─────────────────────────────┐
-│  Full review?  /lets:review --plan │
-│  Execute?      /lets:execute       │
-└────────────────────────────────────┘
+┌─ LETS ────────────────────────────────────┐
+│  Full review?  /lets:review --plan        │
+│  Execute?      /lets:execute              │
+└───────────────────────────────────────────┘
 ```
 
 ---
@@ -258,19 +258,19 @@ Skip the box entirely when `--json` was set. Otherwise the box offers the `/lets
 
 **Local modes (`--local` / default / `--staged` / `--last-commit`), GOOD or REVIEW:**
 ```
-┌─ LETS ──────────────────────────────┐
-│  Commit?       /lets:commit         │
-│  Deep review?  /lets:review --local │
-└─────────────────────────────────────┘
+┌─ LETS ────────────────────────────────────┐
+│  Commit?       /lets:commit               │
+│  Deep review?  /lets:review --local       │
+└───────────────────────────────────────────┘
 ```
 (swap `--local` for `--staged` / `--last-commit` to match the mode used)
 
 **PR mode, GOOD or REVIEW:**
 ```
-┌─ LETS ─────────────────────────────────┐
-│  Deep review?     /lets:review <PR>    │
-│  Full lifecycle?  /lets:github-pr <PR> │
-└────────────────────────────────────────┘
+┌─ LETS ────────────────────────────────────┐
+│  Deep review?     /lets:review <PR>       │
+│  Full lifecycle?  /lets:github-pr <PR>    │
+└───────────────────────────────────────────┘
 ```
 
 **File mode, GOOD or REVIEW:**

--- a/plugins/lets/commands/check.md
+++ b/plugins/lets/commands/check.md
@@ -5,9 +5,7 @@ argument-hint: "[PR-url-or-number|--local|--staged|--last-commit|--plan|--file <
 
 # Quick Local Code Check
 
-Fast inline sanity check from 6 perspectives. Same target selection as `/lets:review` - the difference is depth: `/lets:check` reviews inline (no subagent dispatch), `/lets:review` dispatches expert agents.
-
-> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
+Fast inline sanity check from 6 perspectives. Same target selection as `/lets:review` - the difference is depth: `/lets:check` reviews inline (no subagent dispatch, no AskUserQuestion gates), `/lets:review` dispatches expert agents.
 
 ## Usage
 
@@ -190,9 +188,10 @@ Classify each finding:
 
 ### Output Format
 
+`{target}` is the thing reviewed: `"{N} files changed"` (local modes), `"PR #{number}: {title}"` (PR mode), or `"{filename} ({N} lines)"` (file mode).
+
 ```
 ## Quick Check: {target}
-{target = "{N} files changed" (local) | "PR #{number}: {title}" | "{filename} ({N} lines)"}
 
 ### Verdict: {[OK] GOOD | [!] REVIEW | [X] FIX}
 
@@ -212,7 +211,7 @@ Classify each finding:
 
 ## Step 4.5: JSON Output (--json only)
 
-If `--json` was provided, emit a structured object instead of the console report - schema-compatible with `/lets:review --json` (same severity tiers and finding shape) so consumers can switch between the two:
+If `--json` was provided, emit a structured object instead of the console report. The shape mirrors `/lets:review --json` so a consumer can parse either: same `verdict` values, same severity `tier` values, same `findings[]` fields (`id`, `title`, `tier`, `file`, `line`, `description`, `suggestion`, `agent`), same `summary` object keyed by reviewer. For check, the "reviewer" is always `"check"` and each finding also carries the originating `lens` as an extra field; there is no `systemic[]` array (inline check doesn't do cross-pattern detection - omit it).
 
 ```json
 {
@@ -225,6 +224,7 @@ If `--json` was provided, emit a structured object instead of the console report
       "id": 1,
       "title": "Off-by-one in pagination offset",
       "tier": "SUGGESTION",
+      "agent": "check",
       "lens": "Bug",
       "file": "src/list.py",
       "line": 88,
@@ -232,7 +232,9 @@ If `--json` was provided, emit a structured object instead of the console report
       "suggestion": "Use 0-based offset"
     }
   ],
-  "summary": "2 findings (0 blocker, 2 suggestion). Inline 6-lens check, no agents."
+  "summary": {
+    "check": "2 findings (0 blocker, 2 suggestion); inline 6-lens, no agents"
+  }
 }
 ```
 

--- a/plugins/lets/commands/check.md
+++ b/plugins/lets/commands/check.md
@@ -1,19 +1,26 @@
 ---
 description: Quick sanity check - code (inline 6-perspective) or plan (--plan).
-argument-hint: "[--staged|--last-commit|--plan]"
+argument-hint: "[PR-url-or-number|--local|--staged|--last-commit|--plan|--file <path>] [--json]"
 ---
 
 # Quick Local Code Check
 
-Fast inline sanity check of local changes from 6 perspectives.
+Fast inline sanity check from 6 perspectives. Same target selection as `/lets:review` - the difference is depth: `/lets:check` reviews inline (no subagent dispatch), `/lets:review` dispatches expert agents.
+
+> **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
 
 ## Usage
 
 ```bash
-/lets:check              # uncommitted changes (default)
-/lets:check --staged     # only staged changes
-/lets:check --last-commit # last commit
-/lets:check --plan       # quick plan sanity check
+/lets:check                      # uncommitted changes (default, same as --local)
+/lets:check --local              # uncommitted changes (explicit)
+/lets:check --staged             # only staged changes
+/lets:check --last-commit        # last commit
+/lets:check <PR-url-or-number>   # quick PR sanity (gh pr diff, inline - no agents)
+/lets:check --file <path>        # quick sanity of an existing file (full content, not a diff)
+/lets:check --plan               # quick plan sanity check
+/lets:check --plan <path>        # quick sanity of a specific plan file
+/lets:check ... --json           # structured JSON output instead of console report
 ```
 
 ## When to Use
@@ -22,8 +29,26 @@ Fast inline sanity check of local changes from 6 perspectives.
 - Before commit for significant changes
 - When unsure if code is ready
 - Spot check after refactoring
+- Fast first pass on a PR before a full `/lets:review`
 
-**For full review:** Use `/lets:review` (local or PR, multiple expert agents).
+**For full review:** Use `/lets:review` (same modes, multiple expert agents, deeper analysis). Every mode below has a `/lets:review --<same-flag>` upgrade path.
+
+## Step 0: Determine Mode
+
+Parse the argument(s):
+
+| Argument | Mode | Target |
+|----------|------|--------|
+| `--plan` / `--plan <path>` | Plan review | go to **Plan Mode** section below, skip code steps |
+| `--file <path>` | File review | entire file content (not a diff) |
+| bare PR URL or number (not a flag) | PR | `gh pr diff <PR>` |
+| `--local` / *no argument* | Local (default) | `git diff` (uncommitted) |
+| `--staged` | Local | `git diff --staged` |
+| `--last-commit` | Local | `git diff HEAD~1` |
+
+`--json` is a modifier that can accompany any code mode (not plan mode): emit structured JSON instead of the console report (see Step 4.5). Skip the LETS box and the beads comment when `--json` is set - the caller handles output.
+
+**This command never dispatches subagents in any mode** - all review is inline (Step 3's 6 lenses). PR and file modes just change what gets fed to those lenses.
 
 ## Plan Mode (--plan)
 
@@ -49,42 +74,63 @@ Read the plan and review with 5 lenses (same confidence filter):
 Output same format as code check, then:
 
 ```
-┌─ LETS ─────────────────────────┐
-│  Full review?  /lets:review --plan  │
-│  Execute?      /lets:execute        │
-└─────────────────────────────────────┘
+┌─ LETS ─────────────────────────────┐
+│  Full review?  /lets:review --plan │
+│  Execute?      /lets:execute       │
+└────────────────────────────────────┘
 ```
 
 ---
 
-## Step 1: Get Changes
+## Step 1: Get Target
+
+### Local mode (`--local` / default / `--staged` / `--last-commit`):
 
 ```bash
-# Default: uncommitted changes
-git diff
-
-# Or staged only
-git diff --staged
-
-# Or last commit
-git diff HEAD~1
+git diff              # default / --local: uncommitted
+git diff --staged     # --staged
+git diff HEAD~1       # --last-commit
 ```
 
 If no changes, inform user and exit.
+
+### PR mode (bare PR URL or number):
+
+```bash
+gh pr view <PR> --json state,isDraft,title,body,additions,deletions,changedFiles
+gh pr diff <PR>
+```
+
+- **Skip if** the PR is closed or draft (inform user, exit).
+- **If the PR is large** (rough heuristic: >400 changed lines or >15 files), warn: "This PR is large - `/lets:review <PR>` (full agent review) is a better fit. Running a quick inline pass anyway on the diff." Then proceed.
+- The `gh pr diff` output is the "diff" fed to Step 3.
+
+### File mode (`--file <path>`):
+
+```bash
+LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
+cat "$LETS_PROJECT_ROOT/{path}"
+```
+
+Read the entire file (respect Read-tool pagination for large files - don't blast context; if the file is huge, review the first ~600 lines and say so). The file content is the "diff" fed to Step 3 - this reviews existing code, not changes. If the file doesn't exist, inform user and exit.
 
 ## Step 2: Gather Context
 
 ```bash
 LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
-git diff --stat
 cat "$LETS_PROJECT_ROOT/CLAUDE.md" 2>/dev/null | head -100
 ```
+
+Mode-specific extras:
+- **Local:** `git diff --stat` (or `--staged` / `HEAD~1`)
+- **PR:** `gh pr view <PR> --json title,body` for context; `gh pr diff <PR> --name-only` for the file list
+- **File:** `cat "$LETS_PROJECT_ROOT/$(dirname {path})/CLAUDE.md" 2>/dev/null` for any directory-local rules
 
 ## Step 3: Review with 6 Lenses
 
 ultrathink
 
-Review the diff directly using these 6 perspectives. Think like a senior dev doing a quick PR scan - catch real issues, skip noise.
+Review the target (diff for local/PR modes, full file content for `--file` mode) directly using these 6 perspectives. Think like a senior dev doing a quick PR scan - catch real issues, skip noise. In `--file` mode there's no diff baseline, so judge the code on its own merits rather than "what changed".
 
 ### [Bug] Bugs & Logic
 - Logic errors, off-by-one, edge cases
@@ -140,10 +186,13 @@ Classify each finding:
 
 ## Step 4: Present Results
 
+**If `--json` was set, skip this step - go to Step 4.5 instead.**
+
 ### Output Format
 
 ```
-## Quick Check: {N files changed}
+## Quick Check: {target}
+{target = "{N} files changed" (local) | "PR #{number}: {title}" | "{filename} ({N} lines)"}
 
 ### Verdict: {[OK] GOOD | [!] REVIEW | [X] FIX}
 
@@ -161,30 +210,77 @@ Classify each finding:
 - Minor issues only -> [!] REVIEW
 - Security or critical bugs -> [X] FIX
 
+## Step 4.5: JSON Output (--json only)
+
+If `--json` was provided, emit a structured object instead of the console report - schema-compatible with `/lets:review --json` (same severity tiers and finding shape) so consumers can switch between the two:
+
+```json
+{
+  "date": "2026-02-26",
+  "mode": "check-local",
+  "verdict": "REVIEW",
+  "findings_count": 2,
+  "findings": [
+    {
+      "id": 1,
+      "title": "Off-by-one in pagination offset",
+      "tier": "SUGGESTION",
+      "lens": "Bug",
+      "file": "src/list.py",
+      "line": 88,
+      "description": "Offset starts at 1 instead of 0",
+      "suggestion": "Use 0-based offset"
+    }
+  ],
+  "summary": "2 findings (0 blocker, 2 suggestion). Inline 6-lens check, no agents."
+}
+```
+
+`mode` values: `check-local` | `check-staged` | `check-last-commit` | `check-PR-{number}` | `check-file`. After emitting, STOP - skip Step 5 and the Output box; the caller handles output and task linking.
+
 ## Step 5: Link to Active Task
 
-If issues were found, record in beads:
+Skip entirely if `--json` was set, or if mode is PR / `--file` (those aren't tied to the active branch's task). For local modes, if issues were found, record in beads:
 
 Use the **detect-task** skill to find the active task (read `${CLAUDE_PLUGIN_ROOT}/skills/detect-task/SKILL.md` and follow its detection flow).
 If multiple tasks found, skip beads comment.
 If active task found AND issues detected:
 
 ```bash
-bd comments add <task-id> "Quick check: {verdict}. {N} issues found."
+bd comments add <task-id> "Quick check ({mode}): {verdict}. {N} issues found."
 ```
 
 If clean (no issues) - skip, don't add noise to the task.
 
 ## Output
 
-**If GOOD or REVIEW:**
+Skip the box entirely when `--json` was set. Otherwise the box offers the `/lets:review` upgrade path for the same target:
+
+**Local modes (`--local` / default / `--staged` / `--last-commit`), GOOD or REVIEW:**
 ```
-┌─ LETS ─────────────────┐
-│  Commit? /lets:commit  │
-└────────────────────────┘
+┌─ LETS ──────────────────────────────┐
+│  Commit?       /lets:commit         │
+│  Deep review?  /lets:review --local │
+└─────────────────────────────────────┘
+```
+(swap `--local` for `--staged` / `--last-commit` to match the mode used)
+
+**PR mode, GOOD or REVIEW:**
+```
+┌─ LETS ─────────────────────────────────┐
+│  Deep review?     /lets:review <PR>    │
+│  Full lifecycle?  /lets:github-pr <PR> │
+└────────────────────────────────────────┘
 ```
 
-**If FIX:** No box. Say "Fix the issues above, then run `/lets:check` again."
+**File mode, GOOD or REVIEW:**
+```
+┌─ LETS ────────────────────────────────────┐
+│  Deep review?  /lets:review --file <path> │
+└───────────────────────────────────────────┘
+```
+
+**If FIX (any mode):** No box. Say "Fix the issues above, then run `/lets:check` again." (or `/lets:review --<same-flag>` for a deeper look).
 
 ## Rules
 
@@ -192,18 +288,20 @@ If clean (no issues) - skip, don't add noise to the task.
 
 ## What This Is NOT
 
-- NOT a full code review (use `/lets:review`)
-- NOT multi-agent (no subagents, inline review only)
-- NOT saved to file (console only)
+- NOT multi-agent - inline review only, no subagent dispatch in ANY mode (that's the one thing that never changes vs `/lets:review`)
+- NOT saved to file - console only (`--json` emits to console too, for tooling)
+- NOT a substitute for `/lets:review` on large changes - same target surface, shallower analysis
 
 ## Workflow Integration
 
 ```
-Work -> /lets:check -> /lets:commit -> Push -> PR -> /lets:review
-         ^                                            |
-    Quick inline check                         Full PR review
-    6 perspectives                             multiple agents
+Work -> /lets:check -> /lets:commit -> Push -> PR -> /lets:review <PR> (or /lets:github-pr <PR>)
+         ^                                            ^
+    Quick inline check (any target:                Full agent review
+    local / staged / PR / file / plan)             multiple specialists
 ```
+
+Same flags as `/lets:review` (`--local`, `--staged`, `--last-commit`, `<PR>`, `--file`, `--plan`, `--json`) - reach for `/lets:check` when you want a fast pass, `/lets:review` when you want depth.
 
 ## Notes
 
@@ -211,4 +309,4 @@ Work -> /lets:check -> /lets:commit -> Push -> PR -> /lets:review
 - Focus on actionable issues only - this is a helper, not a blocker
 - No false positives - when in doubt, skip it
 - Be direct, no hedging
-- Reference specific lines from the diff
+- Reference specific lines from the diff (or file, in `--file` mode)

--- a/plugins/lets/commands/done.md
+++ b/plugins/lets/commands/done.md
@@ -104,7 +104,7 @@ AskUserQuestion(
 **Handle response:**
 - **Fix first** -> stop, do NOT proceed to closing
 - **Update scope** -> update task description with `bd update`, then proceed
-- **PR only, keep open** -> proceed to Step 4. In Step 7, create PR but do NOT close the task. In Step 8, skip "Merge & close" option - user explicitly chose to keep the task open for remaining work.
+- **PR only, keep open** -> proceed to Step 4. In Step 8, create PR but do NOT close the task. In Step 9, skip "Merge & close" option - user explicitly chose to keep the task open for remaining work.
 
 **Only continue to Step 4 when all requirements are verified OR user chose "PR only, keep open".**
 
@@ -130,7 +130,42 @@ Commits (N):
 Files: X changed, Y insertions, Z deletions
 ```
 
-## Step 5: Confirm with User
+## Step 5: Update CHANGELOG
+
+Keep `CHANGELOG.md` in sync with merged work so release notes don't have to be back-filled later. This step runs before the branch is pushed/merged, so the CHANGELOG commit lands in the same PR as the task work.
+
+```bash
+LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
+test -f "$LETS_PROJECT_ROOT/CHANGELOG.md" && echo "has-changelog" || echo "no-changelog"
+```
+
+**If `no-changelog`** (no `CHANGELOG.md` at the project root): tell the user "No `CHANGELOG.md` at the project root - skipping changelog update." and proceed to Step 6. Do nothing else.
+
+**If `has-changelog` but the task is pure infra / tests / internal refactor** (no user-visible change to commands, skills, agents, rules, CLI, or README): say so briefly and proceed to Step 6.
+
+**Otherwise** — draft a one-line entry from the task title + commit subjects, pick the right Keep-a-Changelog section (`Added` / `Changed` / `Fixed` / `Removed`), and prepare to insert it under `[Unreleased]` following the file's existing conventions (section headers, task-id link style). Then use **AskUserQuestion**:
+
+```
+AskUserQuestion(
+  questions=[{
+    question: "Add this entry to CHANGELOG.md [Unreleased]?",
+    header: "CHANGELOG",
+    options: [
+      { label: "Add entry", description: "{drafted entry} - under {section}" },
+      { label: "Edit first", description: "Show me the draft, I'll adjust wording before it's written" },
+      { label: "Skip", description: "Don't touch CHANGELOG for this task" }
+    ],
+    multiSelect: false
+  }]
+)
+```
+
+**Handle response:**
+- **Add entry** -> edit `CHANGELOG.md`, then commit it via `/lets:commit` (`docs(<task-id>): update CHANGELOG`). This commit joins the same branch/PR. Then proceed to Step 6.
+- **Edit first** -> show the draft, apply the user's wording, then edit + commit as above. Proceed to Step 6.
+- **Skip** -> proceed to Step 6, CHANGELOG untouched.
+
+## Step 6: Confirm with User
 
 Show what will happen based on `$LETS_PR_FLOW` from LETS Config:
 
@@ -171,10 +206,10 @@ AskUserQuestion(
 Next steps presented via AskUserQuestion (replaces LETS box).
 
 **Handle response:**
-- **Finish** -> proceed to Step 6
+- **Finish** -> proceed to Step 7
 - **Keep working** -> stop, return to work
 
-## Step 6: Document in Beads
+## Step 7: Document in Beads
 
 Add completion comment to the task:
 
@@ -196,7 +231,7 @@ Claude session: ${CLAUDE_SESSION_ID}
 {git diff --stat main..HEAD}"
 ```
 
-## Step 7: Finish Task
+## Step 8: Finish Task
 
 ### Worktree Detection
 
@@ -272,7 +307,7 @@ bd comments add <task-id> "PR #XX created: <PR URL>"
 
 Task stays **open** until PR is merged.
 
-**Do NOT switch branches yet** - user decides in Step 8.
+**Do NOT switch branches yet** - user decides in Step 9.
 
 ### If $LETS_PR_FLOW != github (local merge) AND NOT in worktree:
 
@@ -315,7 +350,7 @@ bd close <task-id> --reason="Merged locally from worktree. Commits: {list}"
 
 Do NOT delete the branch or remove the worktree here - `/lets:worktree remove` handles cleanup.
 
-## Step 8: Output
+## Step 9: Output
 
 ### After PR ($LETS_PR_FLOW == github), NOT in worktree:
 
@@ -454,7 +489,7 @@ AskUserQuestion(
 
 - **NEVER push or create PR without user approval**
 - **NEVER merge without user approval**
-- Document BEFORE finishing (Step 6 before Step 7)
+- Document BEFORE finishing (Step 7 before Step 8)
 - If PR flow: task stays open, user closes after merge
 - If local merge: task closes immediately
 - Respond in user's language

--- a/plugins/lets/commands/execute.md
+++ b/plugins/lets/commands/execute.md
@@ -70,10 +70,10 @@ Commits this session: {N}
 ```
 
 ```
-┌─ LETS ──────────────────────────────────┐
-│  Continue?  /lets:execute               │
-│  End?       /lets:end                   │
-└─────────────────────────────────────────┘
+┌─ LETS ─────────────────────────┐
+│  Continue?  /lets:execute      │
+│  End?       /lets:end          │
+└────────────────────────────────┘
 ```
 
 Exit after showing status.
@@ -168,15 +168,16 @@ $(git log --oneline ${START_REF}..HEAD)"
 
 **After completion:**
 ```
-┌─ LETS ──────────────────────────────────┐
-│  Review?  /lets:review --local          │
-│  Done?    /lets:done                    │
-└─────────────────────────────────────────┘
+┌─ LETS ─────────────────────────┐
+│  Check?   /lets:check          │
+│  Review?  /lets:review --local │
+│  Done?    /lets:done           │
+└────────────────────────────────┘
 ```
 
 **If no plan found:**
 ```
-┌─ LETS ──────────────────────────────────┐
-│  Plan?  /lets:plan                      │
-└─────────────────────────────────────────┘
+┌─ LETS ─────────────────────────┐
+│  Plan?  /lets:plan             │
+└────────────────────────────────┘
 ```

--- a/plugins/lets/commands/github-pr.md
+++ b/plugins/lets/commands/github-pr.md
@@ -1129,10 +1129,10 @@ Posted {N} inline + {M} summary to PR #{number}
 ### After Phase 3 (follow-up done):
 
 ```
-┌─ LETS ───────────────────────────────┐
-│  Approve?  /lets:github-pr --approve │
-│  Merge?    /lets:github-pr --merge   │
-└──────────────────────────────────────┘
+┌─ LETS ───────────────────────────────────┐
+│  Approve?  /lets:github-pr --approve     │
+│  Merge?    /lets:github-pr --merge       │
+└──────────────────────────────────────────┘
 ```
 
 ### After Phase 4 (verdict submitted):
@@ -1140,10 +1140,10 @@ Posted {N} inline + {M} summary to PR #{number}
 ```
 PR #{number} {approved/merged/changes requested}
 
-┌─ LETS ─────────────────────────┐
-│  Done?  /lets:done             │
-│  End?   /lets:end              │
-└────────────────────────────────┘
+┌─ LETS ───────────────────────────────────┐
+│  Done?  /lets:done                       │
+│  End?   /lets:end                        │
+└──────────────────────────────────────────┘
 ```
 
 ### After Phase R (replies posted):
@@ -1151,10 +1151,10 @@ PR #{number} {approved/merged/changes requested}
 ```
 Replied to {N} comments on PR #{number} ({X} fixed, {Y} agreed, {Z} disagreed)
 
-┌─ LETS ─────────────────────────────┐
-│  Done?    /lets:done               │
-│  Status?  /lets:github-pr --status │
-└────────────────────────────────────┘
+┌─ LETS ───────────────────────────────────┐
+│  Done?    /lets:done                     │
+│  Status?  /lets:github-pr --status       │
+└──────────────────────────────────────────┘
 ```
 
 ### After Phase R (saved for later):
@@ -1181,9 +1181,9 @@ Response saved to .lets/execution/pr-{number}/response.json
 ```
 Review state cleaned up.
 
-┌─ LETS ─────────────────────────────┐
-│  New review?  /lets:github-pr <PR> │
-└────────────────────────────────────┘
+┌─ LETS ───────────────────────────────────┐
+│  New review?  /lets:github-pr <PR>       │
+└──────────────────────────────────────────┘
 ```
 
 ## Rules

--- a/plugins/lets/commands/github-pr.md
+++ b/plugins/lets/commands/github-pr.md
@@ -3,9 +3,11 @@ description: GitHub PR review lifecycle - analyze, discuss, post inline comments
 argument-hint: "[PR-url-or-number|--respond|--follow-up|--approve|--merge|--status|--cancel]"
 ---
 
-# PR Review Lifecycle
+# GitHub PR Review Lifecycle
 
 Full GitHub PR review lifecycle: analyze code, discuss findings with user, post inline comments, follow-up on fixes, approve or request changes.
+
+**GitHub only.** This command drives PRs exclusively via the `gh` CLI. Bitbucket and local-merge PR flows are not implemented (`LETS_PR_FLOW=bitbucket|local` users finish tasks via `/lets:done`, not this command).
 
 **Requires:** `gh` CLI installed and authenticated.
 
@@ -14,14 +16,14 @@ Full GitHub PR review lifecycle: analyze code, discuss findings with user, post 
 ## Usage
 
 ```bash
-/lets:pr <PR-url-or-number>     # Start new review
-/lets:pr                        # Resume from saved state
-/lets:pr --follow-up            # Check if fixes addressed comments
-/lets:pr --respond [PR]         # Author: triage review comments, fix, reply
-/lets:pr --approve              # Approve PR
-/lets:pr --merge                # Merge PR
-/lets:pr --status               # Show current review state
-/lets:pr --cancel               # Clean up state, abandon review
+/lets:github-pr <PR-url-or-number>     # Start new review
+/lets:github-pr                        # Resume from saved state
+/lets:github-pr --follow-up            # Check if fixes addressed comments
+/lets:github-pr --respond [PR]         # Author: triage review comments, fix, reply
+/lets:github-pr --approve              # Approve PR
+/lets:github-pr --merge                # Merge PR
+/lets:github-pr --status               # Show current review state
+/lets:github-pr --cancel               # Clean up state, abandon review
 ```
 
 ## Step 1: Detect Mode
@@ -57,7 +59,7 @@ STATE_FILE="$PR_DIR/review.json"
 ### --status flag (exit early)
 
 If --status: read state file, show progress summary (phase, findings count, posted status), exit.
-If no state file: "No active PR review. Run `/lets:pr <PR>` to start one."
+If no state file: "No active PR review. Run `/lets:github-pr <PR>` to start one."
 
 ### --cancel flag (cleanup and exit)
 
@@ -70,7 +72,7 @@ If --cancel:
 ### Route to phase
 
 **State guard:** If `--follow-up`, `--approve`, `--merge`, or `--respond` is specified but no state file exists:
-1. If a PR number is also provided (e.g., `/lets:pr --approve 2`), create a minimal state from `gh pr view`:
+1. If a PR number is also provided (e.g., `/lets:github-pr --approve 2`), create a minimal state from `gh pr view`:
    ```bash
    REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner) || { echo "ERROR: gh repo view failed - check 'gh auth status'"; exit 1; }
 [ -z "$REPO" ] && { echo "ERROR: gh repo view returned empty REPO"; exit 1; }
@@ -81,7 +83,7 @@ If --cancel:
    For `--respond` specifically, create a minimal response state (not review state):
    - If PR number provided: fetch PR info, create `$PR_DIR/response.json`, continue to Phase R
    - If no PR number: check for existing `pr-[0-9]*/response.json` files, or stop
-2. If no PR number - stop: "No active PR review found. Run `/lets:pr <PR>` to start one."
+2. If no PR number - stop: "No active PR review found. Run `/lets:github-pr <PR>` to start one."
 
 | State | Action |
 |-------|--------|
@@ -368,7 +370,7 @@ AskUserQuestion(
 Handle response:
 - Post all -> proceed to 3.3
 - Review again -> loop back to 3.1
-- Save for later -> save state, show LETS box with `/lets:pr` to resume
+- Save for later -> save state, show LETS box with `/lets:github-pr` to resume
 
 ### 3.3 Verify line numbers against diff
 
@@ -529,7 +531,7 @@ CURRENT_SHA=$(gh pr view <PR> --json headRefOid -q .headRefOid)
 
 If REVIEW_SHA == CURRENT_SHA:
   "No new commits since review. Waiting for fixes."
-  Show LETS box: /lets:pr --approve (if ready) or /lets:pr --status
+  Show LETS box: /lets:github-pr --approve (if ready) or /lets:github-pr --status
   Exit.
 
 ### 4.2 Checkout updated PR and get fix delta
@@ -1118,19 +1120,19 @@ No LETS box needed - flow continues.
 ```
 Posted {N} inline + {M} summary to PR #{number}
 
-┌─ LETS ────────────────────────────────┐
-│  Follow-up?  /lets:pr --follow-up     │
-│  Approve?    /lets:pr --approve       │
-└───────────────────────────────────────┘
+┌─ LETS ───────────────────────────────────┐
+│  Follow-up?  /lets:github-pr --follow-up │
+│  Approve?    /lets:github-pr --approve   │
+└──────────────────────────────────────────┘
 ```
 
 ### After Phase 3 (follow-up done):
 
 ```
-┌─ LETS ─────────────────────────┐
-│  Approve?  /lets:pr --approve  │
-│  Merge?    /lets:pr --merge    │
-└────────────────────────────────┘
+┌─ LETS ───────────────────────────────┐
+│  Approve?  /lets:github-pr --approve │
+│  Merge?    /lets:github-pr --merge   │
+└──────────────────────────────────────┘
 ```
 
 ### After Phase 4 (verdict submitted):
@@ -1149,10 +1151,10 @@ PR #{number} {approved/merged/changes requested}
 ```
 Replied to {N} comments on PR #{number} ({X} fixed, {Y} agreed, {Z} disagreed)
 
-┌─ LETS ─────────────────────────┐
-│  Done?    /lets:done           │
-│  Status?  /lets:pr --status    │
-└────────────────────────────────┘
+┌─ LETS ─────────────────────────────┐
+│  Done?    /lets:done               │
+│  Status?  /lets:github-pr --status │
+└────────────────────────────────────┘
 ```
 
 ### After Phase R (saved for later):
@@ -1160,18 +1162,18 @@ Replied to {N} comments on PR #{number} ({X} fixed, {Y} agreed, {Z} disagreed)
 ```
 Response saved to .lets/execution/pr-{number}/response.json
 
-┌─ LETS ──────────────────────────────┐
-│  Resume?  /lets:pr --respond {PR}   │
-└─────────────────────────────────────┘
+┌─ LETS ───────────────────────────────────┐
+│  Resume?  /lets:github-pr --respond {PR} │
+└──────────────────────────────────────────┘
 ```
 
 ### After --status:
 
 ```
-┌─ LETS ────────────────────────────────┐
-│  Resume?     /lets:pr                 │
-│  Follow-up?  /lets:pr --follow-up     │
-└───────────────────────────────────────┘
+┌─ LETS ───────────────────────────────────┐
+│  Resume?     /lets:github-pr             │
+│  Follow-up?  /lets:github-pr --follow-up │
+└──────────────────────────────────────────┘
 ```
 
 ### After --cancel:
@@ -1179,9 +1181,9 @@ Response saved to .lets/execution/pr-{number}/response.json
 ```
 Review state cleaned up.
 
-┌─ LETS ─────────────────────────┐
-│  New review?  /lets:pr <PR>    │
-└────────────────────────────────┘
+┌─ LETS ─────────────────────────────┐
+│  New review?  /lets:github-pr <PR> │
+└────────────────────────────────────┘
 ```
 
 ## Rules

--- a/plugins/lets/commands/install-deprecated.md
+++ b/plugins/lets/commands/install-deprecated.md
@@ -77,7 +77,7 @@ Team:     /lets:plan -> /lets:team run -> monitor -> /lets:review --local -> /le
 | `/lets:commit` | Code | Ready to commit (also triggers automatically on "commit") |
 | `/lets:check` | Code | Quick sanity check - code (~30s) or plan (--plan) |
 | `/lets:review` | Code | Full deep review (~2-3 min) |
-| `/lets:pr` | Code | PR review lifecycle (review, respond, follow-up, approve) |
+| `/lets:github-pr` | Code | GitHub PR review lifecycle (review, respond, follow-up, approve) |
 | `/lets:opinion` | Expert | Technical decision needed |
 | `/lets:ask` | Expert | Quick question to one expert |
 | `/lets:init` | Setup | Initialize LETS in a new project; re-run for self-heal or config change |

--- a/plugins/lets/commands/note.md
+++ b/plugins/lets/commands/note.md
@@ -31,10 +31,10 @@ If no active task or multiple tasks found - ask user which task to add a note to
 
 ```bash
 bd show <task-id>
-bd comments list <task-id>
+bd comments <task-id>
 ```
 
-Check existing comments to avoid duplicating info.
+Read the full description and all comments. Check existing comments to avoid duplicating info.
 
 ## Step 3: Ask What to Note
 

--- a/plugins/lets/commands/plan.md
+++ b/plugins/lets/commands/plan.md
@@ -1,6 +1,6 @@
 ---
 description: Structured planning - explore codebase, design architecture, evaluate options, produce detailed implementation plan
-argument-hint: "[feature description]"
+argument-hint: "[feature description] [--fast]"
 ---
 
 # Plan
@@ -11,11 +11,19 @@ Turn a task or idea into a detailed implementation plan. Clarifies scope, explor
 
 > **IMPORTANT:** If the spec below invokes any deferred tool (e.g. `AskUserQuestion`), you MUST load and call it as specified. Never skip the call, never substitute a default answer of your own — the tool invocation is part of the contract. This is critical.
 
+## --fast mode
+
+`/lets:plan --fast` (combinable with a task-id or feature description, e.g. `/lets:plan lets-abc --fast`) skips the three subagent-dispatch phases - **Step 4** (explorer agents), **Step 6** (architect agents), **Step 7** (expert agents) - and replaces them with orchestrator-only equivalents (read files yourself, draft approaches inline, self-evaluate risks). Use it when the user explicitly wants a collaborative talk-through without subagent budget: "let's just plan it together, I'll review". Everything else - clarifying questions, interactive discussion, plan format, beads recording, the saved file - is identical to the full flow. The plan's shape doesn't change; only *how* it's built.
+
+When `--fast` is **not** set, run the full flow exactly as written.
+
 ## Step 1: Capture the Goal
 
-**If argument provided:** use it as the feature goal.
+**Parse the argument:** strip a `--fast` token if present (sets fast mode); the rest is the feature goal.
 
-**If no argument:** ask:
+**If a feature goal was provided:** use it.
+
+**If no goal provided:** ask:
 
 > "What are you trying to build or change?"
 
@@ -73,7 +81,20 @@ LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cat "$LETS_PROJECT_ROOT/CLAUDE.md" 2>/dev/null | head -200
 ```
 
+### --fast: orchestrator-only exploration
+
+**If `--fast` is set:** skip the explorer-dispatch phase below (Exploration Strategy, Show Exploration Plan, Launch Explorers). Instead, build the Codebase Map yourself:
+
+- Read/Grep/Glob the files relevant to the feature goal + user clarifications, on demand - prioritize the entry points, the modules the feature touches, and the existing patterns it should follow.
+- Iterate: read a file, learn something, decide what to read next. Stop when you can describe the relevant surface confidently.
+- Synthesize the same `## Codebase Map` structure (sections by area), then go to the **Checkpoint: Exploration Review** below (same checkpoint, same options).
+- Note any area you couldn't cover ("didn't read X - low confidence there") so the user can ask for more.
+
+Then jump to **Checkpoint: Exploration Review**.
+
 ### Exploration Strategy
+
+*(full mode only - skipped under `--fast`)*
 
 Decide how many explorers to launch and what each should focus on.
 
@@ -261,9 +282,17 @@ AskUserQuestion(
 
 ## Step 6: Architecture Design
 
-Launch one architect agent per selected approach. Each gets a focused brief with user's decisions baked in.
+### --fast: orchestrator-only design
+
+**If `--fast` is set:** skip the architect dispatch (Architect Brief, parallel launch). Instead, draft the architecture yourself for each approach the user selected in Step 5 - using the codebase map, the user's clarifications, and your own analysis. Produce the same `## {Approach Name}` shape (Summary / Components / Files / Data Flow / Trade-offs) for each. Present the design(s) to the user, then go to **Checkpoint: Architecture Review** below (same checkpoint, same options).
+
+Then jump to **Checkpoint: Architecture Review** (use the multi-approach or single-approach variant as applicable).
 
 ### Architect Brief
+
+*(full mode only - skipped under `--fast`)*
+
+Launch one architect agent per selected approach. Each gets a focused brief with user's decisions baked in.
 
 For each selected approach:
 
@@ -381,9 +410,19 @@ AskUserQuestion(
 
 ## Step 7: Expert Evaluation
 
-Evaluate the chosen architecture with domain experts.
+### --fast: orchestrator-only evaluation
+
+**If `--fast` is set:** skip the expert dispatch (Suggest Experts, Expert Selection checkpoint, Dispatch Experts). Instead, self-evaluate the chosen architecture from project context: name the real risks, the proportionality concerns (overengineering / underspec), and the trade-offs. Present them in the same `## Expert Evaluation` shape (a short list of findings + a Risks & Suggestions list), then add:
+
+> *Fast mode skipped the expert agents. For a second opinion before executing, run `/lets:opinion` or `/lets:review --plan` after the plan is saved.*
+
+Then go to the **Checkpoint: Evaluation Results** below (same checkpoint, same options).
 
 ### Suggest Experts
+
+*(full mode only - skipped under `--fast`)*
+
+Evaluate the chosen architecture with domain experts.
 
 Based on what the feature touches, suggest relevant experts:
 
@@ -698,6 +737,7 @@ Plan: .lets/plans/${SLUG}.md"
 ## Plan Ready: **{task title}** (`{task-id}`)
 
 Saved: `.lets/plans/{branch-slug}.md`
+Built: {full flow (explorer + architect + expert agents) | fast mode (orchestrator-only - no subagents)}
 
 ### Approach
 {chosen option - 2 sentences}
@@ -715,21 +755,25 @@ Start a new session to execute the plan with clean context.
 ```
 
 ```
-┌─ LETS ──────────────────────────────────┐
-│  Review plan? /lets:review --plan       │
-│  Execute?     /lets:execute             │
-│  New session? /lets:start               │
-└─────────────────────────────────────────┘
+┌─ LETS ─────────────────────────────┐
+│  Check plan?   /lets:check --plan  │
+│  Review plan?  /lets:review --plan │
+│  Execute?      /lets:execute       │
+│  New session?  /lets:start         │
+└────────────────────────────────────┘
 ```
+
+(In fast mode, nudge `/lets:check --plan` or `/lets:review --plan` first - the plan didn't get agent review.)
 
 ## Rules
 
 - **NEVER write code** outside the plan document in `.lets/plans/`
-- **NEVER skip clarifying questions** (Step 3) - vague input produces vague plans
+- **NEVER skip clarifying questions** (Step 3) - vague input produces vague plans, in fast mode too
 - **EVERY phase transition requires user approval** via AskUserQuestion
 - **NEVER hardcode approach names** like "Minimal/Maximal/Pragmatic" - derive from exploration context
 - **ALL parallel agents in a SINGLE message** - never sequential when parallel is possible
-- **Exact file paths** in plan - verified against explorer findings
+- **`--fast` skips Steps 4/6/7 subagent dispatch only** - it does NOT skip the clarifying questions, the checkpoints, the discussion, or any user approval gate. Output plan format is identical; record which mode was used in the Plan Ready output.
+- **Exact file paths** in plan - verified against explorer findings (or orchestrator's own reads in fast mode)
 - **Complete code snippets** - no stubs, no "implement X here"
 - **Plan is the artifact** - session ends when plan is saved
 - Respond in user's language

--- a/plugins/lets/commands/review.md
+++ b/plugins/lets/commands/review.md
@@ -708,10 +708,10 @@ bd comments add <task-id> "Plan review: {verdict}. {N} issues found."
 
 **If approved:**
 ```
-┌─ LETS ──────────────────────────────────┐
-│  Execute?     /lets:execute             │
-│  New session? /lets:start               │
-└─────────────────────────────────────────┘
+┌─ LETS ───────────────────────┐
+│  Execute?      /lets:execute │
+│  New session?  /lets:start   │
+└──────────────────────────────┘
 ```
 
 **If needs revision:** No box. List action items to fix in the plan first.
@@ -756,9 +756,10 @@ Work -> /lets:commit -> Push -> PR -> /lets:review <PR>
 
 **If no issues or approved:**
 ```
-┌─ LETS ─────────────────┐
-│  Commit? /lets:commit  │
-└────────────────────────┘
+┌─ LETS ───────────────────────┐
+│  Commit?  /lets:commit       │
+│  Check?   /lets:check        │
+└──────────────────────────────┘
 ```
 
 **If changes requested:** No box. List issues to fix first.

--- a/plugins/lets/commands/start.md
+++ b/plugins/lets/commands/start.md
@@ -20,7 +20,7 @@ Restore context and prepare for work. **User MUST select a task before working.*
 **If `<task-id>` provided** (e.g., `/lets:start lets-rmcwo`):
 - Skip Steps 1, 3, 5 (session history, status overview, task selection)
 - Run Step 2 (git state) briefly
-- `bd show <task-id>` + `bd comments list <task-id> --limit 3` for context
+- `bd show <task-id>` + `bd comments <task-id>` for context — read the FULL description and ALL comments, never truncate
 - Jump to Step 6 (branch) with this task
 
 **If `--continue`:**
@@ -30,7 +30,7 @@ Restore context and prepare for work. **User MUST select a task before working.*
 - If multiple -> show selection with context from recent sessions
 - If none -> fall through to full flow
 
-**If no arguments** -> full flow (Steps 1-8 as below)
+**If no arguments** -> full flow (Steps 1-9 as below)
 
 ## Step 1: Previous Session Context
 
@@ -101,7 +101,16 @@ After task is selected, delegate to the **take-task** skill to claim it and prep
 
 The take-task skill handles: setting task to `in_progress`, uncommitted changes check, worktree detection, branch creation/switching, offering worktree option, context recovery, saving session start ref.
 
-## Step 7: Task Size Assessment
+## Step 7: Suggest Session Rename
+
+After the task is claimed, suggest renaming the Claude Code session so the statusline reflects the active task. `/rename` is a built-in slash command the **user** invokes — the assistant cannot run it — so present it as a ready-to-paste suggestion, not an action:
+
+> Tip: name this session for quick context — `/rename {slug}`
+
+- Slug: short, lowercase, dash-separated, derived from the task title (e.g. **Add CHANGELOG step to /lets:done** -> `changelog-step-done`). Keep under ~30 chars; compress long titles to the 2-4 most distinctive words.
+- This is a one-line suggestion, not a gate — continue regardless of whether the user runs it.
+
+## Step 8: Task Size Assessment
 
 Once task is selected, assess complexity:
 
@@ -112,7 +121,7 @@ Once task is selected, assess complexity:
 | Medium (2-8 hrs) | Suggest `/lets:plan` then `/lets:execute` |
 | Large (> 8 hrs) | Require `/lets:plan` + break into subtasks |
 
-## Step 8: Ready to Work
+## Step 9: Ready to Work
 
 After task is selected and branch is ready, show reminders and welcome box.
 
@@ -120,6 +129,7 @@ After task is selected and branch is ready, show reminders and welcome box.
 
 ```
 ## Reminders
+- Name this session: `/rename {slug}`
 - Check context window: `/context`
 - For technical decisions: `/lets:opinion`
 - When task done: `/lets:commit` - `/lets:done` - `/lets:end`

--- a/plugins/lets/commands/team.md
+++ b/plugins/lets/commands/team.md
@@ -111,9 +111,9 @@ Check:
 LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
 cat "$LETS_PROJECT_ROOT/CLAUDE.md" 2>/dev/null | head -200
 
-# For each task:
+# For each task (read full description + all comments):
 bd show <task-id>
-bd comments list <task-id>
+bd comments <task-id>
 
 # Stack detection
 ls package.json pyproject.toml Cargo.toml go.mod composer.json Gemfile 2>/dev/null

--- a/plugins/lets/commands/team.md
+++ b/plugins/lets/commands/team.md
@@ -452,10 +452,11 @@ All commits landed on current branch ({branch-name}).
 ```
 
 ```
-┌─ LETS ──────────────────────────────────┐
-│  Review?  /lets:review --local          │
-│  Done?    /lets:done                    │
-└─────────────────────────────────────────┘
+┌─ LETS ─────────────────────────┐
+│  Check?   /lets:check --local  │
+│  Review?  /lets:review --local │
+│  Done?    /lets:done           │
+└────────────────────────────────┘
 ```
 
 ---
@@ -510,9 +511,9 @@ Started: {time}
 ```
 
 ```
-┌─ LETS ──────────────────────────────────┐
-│  Stop?  /lets:team stop                 │
-└─────────────────────────────────────────┘
+┌─ LETS ─────────────────────────┐
+│  Stop?  /lets:team stop        │
+└────────────────────────────────┘
 ```
 
 ---
@@ -576,9 +577,10 @@ In-progress work from stopped teammates may be lost if they didn't commit before
 
 Check teammate commits: git log --oneline ${BASE_SHA}..HEAD
 
-┌─ LETS ──────────────────────────────────┐
-│  Review?  /lets:review --local          │
-└─────────────────────────────────────────┘
+┌─ LETS ─────────────────────────┐
+│  Check?   /lets:check --local  │
+│  Review?  /lets:review --local │
+└────────────────────────────────┘
 ```
 
 ---

--- a/plugins/lets/commands/worktree.md
+++ b/plugins/lets/commands/worktree.md
@@ -192,10 +192,10 @@ Open a new terminal for the worktree:
 cd {absolute-worktree-path} && claude
 ```
 
-┌─ LETS ─────────────────────────┐
-│  Continue?  /lets:start        │
-│  List?      /lets:worktree list│
-└────────────────────────────────┘
+┌─ LETS ──────────────────────────┐
+│  Continue?  /lets:start         │
+│  List?      /lets:worktree list │
+└─────────────────────────────────┘
 ```
 
 **If switching to worktree:**
@@ -206,10 +206,10 @@ Branch: worktree-{name}
 Beads: {shared via redirect / not available}
 LETS: {symlinked / not available}
 
-┌─ LETS ─────────────────────────┐
-│  Start?   /lets:start          │
-│  Info?    /lets:worktree info  │
-└────────────────────────────────┘
+┌─ LETS ──────────────────────────┐
+│  Start?  /lets:start            │
+│  Info?   /lets:worktree info    │
+└─────────────────────────────────┘
 ```
 
 ---
@@ -252,10 +252,10 @@ cd "${WORKTREE_PATH}" && git status --short 2>/dev/null | head -5
 
 {N} active worktrees
 
-┌─ LETS ─────────────────────────┐
-│  Create?  /lets:worktree create│
-│  Remove?  /lets:worktree remove│
-└────────────────────────────────┘
+┌─ LETS ──────────────────────────┐
+│  Create?  /lets:worktree create │
+│  Remove?  /lets:worktree remove │
+└─────────────────────────────────┘
 ```
 
 Note: `.claude/worktrees/` are agent worktrees (native Claude Code). `.worktrees/` are interactive (this command).
@@ -364,9 +364,9 @@ AskUserQuestion(
 Worktree removed: .worktrees/{name}/
 Branch: {deleted / kept}
 
-┌─ LETS ─────────────────────────┐
-│  List?  /lets:worktree list    │
-└────────────────────────────────┘
+┌─ LETS ──────────────────────────┐
+│  List?  /lets:worktree list     │
+└─────────────────────────────────┘
 ```
 
 ---
@@ -421,10 +421,10 @@ Beads: {shared via redirect / local (stale) / not available}
 LETS: {symlinked / not available}
 Changes: {clean / N uncommitted files}
 
-┌─ LETS ─────────────────────────┐
-│  List?    /lets:worktree list  │
-│  Remove?  /lets:worktree remove│
-└────────────────────────────────┘
+┌─ LETS ──────────────────────────┐
+│  List?    /lets:worktree list   │
+│  Remove?  /lets:worktree remove │
+└─────────────────────────────────┘
 ```
 
 **If in main repo:**
@@ -435,10 +435,10 @@ Changes: {clean / N uncommitted files}
 You are in the main repository (not a worktree).
 Path: {toplevel}
 
-┌─ LETS ─────────────────────────┐
-│  Create?  /lets:worktree create│
-│  List?    /lets:worktree list  │
-└────────────────────────────────┘
+┌─ LETS ──────────────────────────┐
+│  Create?  /lets:worktree create │
+│  List?    /lets:worktree list   │
+└─────────────────────────────────┘
 ```
 
 ---

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -343,7 +343,7 @@ This applies when: presenting implementation approaches, choosing between soluti
 | `/lets:commit` | Code | Ready to commit (also auto-triggers on "commit", "закоміть") |
 | `/lets:check` | Code | Quick sanity check (~30s) - inline 6-lens; same targets as `/lets:review` (local/staged/last-commit/PR/`--file`/`--plan`/`--json`), no subagents |
 | `/lets:review` | Code | Full deep review (~2-3 min) |
-| `/lets:github-pr` | Code | PR review lifecycle (review, respond, follow-up, approve) |
+| `/lets:github-pr` | Code | GitHub PR review lifecycle (review, respond, follow-up, approve) |
 | `/lets:opinion` | Expert | Technical decision (dynamic agent count) |
 | `/lets:ask` | Expert | Quick expert consultation (1 agent) |
 | `/lets:brainstorm` | Planning | Interactive ideation - review backlog, explore ideas, quick brainstorm, cleanup |

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -226,7 +226,7 @@ Two separate lifecycles:
 - **Task:** picked at start ... `/lets:done` (may span multiple sessions)
 
 **Review options:**
-- `/lets:check` - quick sanity check (~30 sec), before any commit
+- `/lets:check` - quick inline sanity check (~30 sec); same target flags as `/lets:review` but no subagents - before any commit, or a fast first pass on a PR
 - `/lets:review` - full deep review (~2-3 min), works locally OR on GitHub PR
 
 **When to use which:**
@@ -341,13 +341,13 @@ This applies when: presenting implementation approaches, choosing between soluti
 | `/lets:end` | Session | End of session |
 | `/lets:done` | Task | Task is complete |
 | `/lets:commit` | Code | Ready to commit (also auto-triggers on "commit", "закоміть") |
-| `/lets:check` | Code | Quick sanity check - code (~30s) or plan (--plan) |
+| `/lets:check` | Code | Quick sanity check (~30s) - inline 6-lens; same targets as `/lets:review` (local/staged/last-commit/PR/`--file`/`--plan`/`--json`), no subagents |
 | `/lets:review` | Code | Full deep review (~2-3 min) |
 | `/lets:github-pr` | Code | PR review lifecycle (review, respond, follow-up, approve) |
 | `/lets:opinion` | Expert | Technical decision (dynamic agent count) |
 | `/lets:ask` | Expert | Quick expert consultation (1 agent) |
 | `/lets:brainstorm` | Planning | Interactive ideation - review backlog, explore ideas, quick brainstorm, cleanup |
-| `/lets:plan` | Planning | Structured planning with agents - architecture + implementation plan |
+| `/lets:plan` | Planning | Structured planning with agents - architecture + implementation plan (`--fast` = orchestrator-only, skips explorer/architect/expert subagents) |
 | `/lets:execute` | Planning | Execute plan from /lets:plan via native plan mode |
 | `/lets:status` | Utility | Task overview and project status |
 | `/lets:worktree` | Utility | Create/manage interactive worktrees for parallel work |

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -106,6 +106,13 @@ AUTO MODE (autonomous execution: `/loop`, `/lets:execute` auto-flow, `/lets:team
 **Soft stops** (pause and ask):
 - Decision point with 2+ viable approaches → use `AskUserQuestion`, don't pick autonomously.
 - New large scope late in long session → suggest finishing current + `/lets:end` first.
+- Implementation about to start without an approved plan → present the plan, wait. Don't begin editing.
+
+**Plan-visibility gate** (applies even in AUTO MODE):
+- Before editing code/files the user has not already seen and approved as a concrete plan — present the plan first: per task/file, what changes, in what order. Wait for "go". AUTO MODE speeds up execution of an *approved* plan; it never authorizes starting unseen work.
+- "Execute immediately" = run the next step of an already-approved plan without re-confirming each step. It does NOT mean "skip showing the plan".
+- "Let's think about how to do X" / "подумаємо як" / "проаналізуй" / "how to do X?" = request for a plan or analysis, NOT a green light to edit. Produce the plan/analysis, stop, wait.
+- Multi-task batches: show the full batch breakdown (per-task approach + files touched) before the first edit. One approval covers the whole batch — no need to re-ask per task — but the user must see it before any code changes.
 
 **Escape hatch:**
 - User interrupt = stop the current action, ack the interruption, await direction. Don't resume without explicit re-approval.
@@ -113,7 +120,7 @@ AUTO MODE (autonomous execution: `/loop`, `/lets:execute` auto-flow, `/lets:team
 
 ## Agent Rules
 
-- When launching expert agents for `/lets:review`, `/lets:pr`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:brainstorm` - use ONLY `lets:*` agents (`lets:architect`, `lets:security`, etc.)
+- When launching expert agents for `/lets:review`, `/lets:github-pr`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:brainstorm` - use ONLY `lets:*` agents (`lets:architect`, `lets:security`, etc.)
 - `lets:actor` is a special meta-agent: requires explicit user request + personality source (URL or file path). Never auto-select. Use `actor-fetch-personality` skill to fetch personality before dispatch.
 - Never use `general-purpose` or other non-lets subagent types for expert work
 
@@ -208,8 +215,8 @@ Worktree:  /lets:worktree create -> `cd .worktrees/<name>/ && claude` -> /lets:s
 
 Team:      /lets:plan -> /lets:team run -> monitor -> /lets:review --local -> /lets:done
 
-PR review:  /lets:pr <PR> -> discuss -> post -> /lets:pr --follow-up -> /lets:pr --approve
-PR respond: /lets:pr --respond <PR> -> triage -> fix -> reply
+PR review:  /lets:github-pr <PR> -> discuss -> post -> /lets:github-pr --follow-up -> /lets:github-pr --approve
+PR respond: /lets:github-pr --respond <PR> -> triage -> fix -> reply
 ```
 
 If a plan exists from `/lets:plan`, use `/lets:execute` to implement it. Execute enters native plan mode; use `/lets:commit` at natural commit points.
@@ -226,7 +233,7 @@ Two separate lifecycles:
 - Small change -> `/lets:check` -> commit
 - Significant change -> `/lets:check` -> `/lets:review --local` -> fix -> commit -> PR
 - PR already exists -> `/lets:review <PR>` -> comment on PR
-- Full PR lifecycle -> `/lets:pr <PR>` -> discuss -> post inline -> follow-up -> approve
+- Full PR lifecycle -> `/lets:github-pr <PR>` -> discuss -> post inline -> follow-up -> approve
 - Existing file quality -> `/lets:review --file <path>`
 - Quick plan check -> `/lets:check --plan`
 
@@ -275,7 +282,7 @@ Every milestone should show a LETS box with relevant next steps.
 
 **Rule:** If AI made changes -> always suggest `/lets:check` first.
 
-**Exception — internal invocation:** When a `/lets:*` command is invoked programmatically by another command (e.g., `/lets:review --json` called by `/lets:pr`), the inner command's LETS box is waived. Only the outer command shows its box to avoid duplicate / conflicting next-step suggestions in one response.
+**Exception — internal invocation:** When a `/lets:*` command is invoked programmatically by another command (e.g., `/lets:review --json` called by `/lets:github-pr`), the inner command's LETS box is waived. Only the outer command shows its box to avoid duplicate / conflicting next-step suggestions in one response.
 
 **Active work:**
 ```
@@ -336,7 +343,7 @@ This applies when: presenting implementation approaches, choosing between soluti
 | `/lets:commit` | Code | Ready to commit (also auto-triggers on "commit", "закоміть") |
 | `/lets:check` | Code | Quick sanity check - code (~30s) or plan (--plan) |
 | `/lets:review` | Code | Full deep review (~2-3 min) |
-| `/lets:pr` | Code | PR review lifecycle (review, respond, follow-up, approve) |
+| `/lets:github-pr` | Code | PR review lifecycle (review, respond, follow-up, approve) |
 | `/lets:opinion` | Expert | Technical decision (dynamic agent count) |
 | `/lets:ask` | Expert | Quick expert consultation (1 agent) |
 | `/lets:brainstorm` | Planning | Interactive ideation - review backlog, explore ideas, quick brainstorm, cleanup |

--- a/plugins/lets/skills/take-task/SKILL.md
+++ b/plugins/lets/skills/take-task/SKILL.md
@@ -125,10 +125,10 @@ If the branch already existed (continuing a multi-session task):
 
 ```bash
 bd show <task-id>
-bd comments list <task-id>
+bd comments <task-id>
 ```
 
-Present: "Resuming **{task title}** (`{task-id}`). Last session: {summary from latest beads comment}"
+Read the full description and ALL comments — they hold the multi-session context. Present: "Resuming **{task title}** (`{task-id}`). Last session: {summary from latest beads comment}"
 
 ## Output
 


### PR DESCRIPTION
## Summary

Batch of fixes/improvements to the plugin's user-facing command & rules surface (`plugins/lets/commands/*.md`, `plugins/lets/skills/*`, `plugins/lets/rules/lets-rules.md`, `CLAUDE.md`, `README.md`). 10 commits:

- **`refactor(lets-v1rm1.2)`** — rename `/lets:pr` → `/lets:github-pr`. The PR review lifecycle command supports GitHub only (via `gh` CLI); Bitbucket and local-merge PR flows aren't implemented (those finish via `/lets:done`). File `pr.md` → `github-pr.md` (git-tracked rename); all references updated across commands, skills, rules, CLAUDE.md, README; H1 + intro now say "GitHub only"; the 7 LETS boxes in the file realigned for the longer command name.
- **`feat(lets-sjtiy.1)`** — plan-visibility gate in `lets-rules.md` AUTO MODE: present the plan before any edits even in AUTO MODE; one approval covers a multi-task batch; "execute immediately" = next step of an *approved* plan, not "skip the plan"; "let's think about how to do X" = a plan request, not an edit go-ahead. Plus a matching Soft stop line.
- **`fix(lets-8ptef)`** — `bd comments list <id> [--limit N]` corrected to `bd comments <id>` in `/lets:start`, `/lets:note`, `/lets:team`, and the `take-task` skill (`bd comments` has no `list` subcommand or `--limit` flag; the bad syntax made `/lets:start <task-id>` fail on bd v1.0.2). Those flows now also instruct reading the full task description and all comments.
- **`feat(lets-gzsho)`** — `/lets:start` suggests `/rename {slug}` after a task is claimed so the statusline reflects the active task (paste-ready hint; `/rename` is user-invoked).
- **`feat(lets-v1rm1.1)`** — `/lets:done` Step 5: when `CHANGELOG.md` exists at the root and the task touched user-visible files, offer (AskUserQuestion) to add a `[Unreleased]` entry and commit it via `/lets:commit`; skip silently and say so when there's no `CHANGELOG.md`.
- **`feat(lets-qadj0)`** (+ follow-up) — `/lets:check` parameter parity with `/lets:review`: now accepts `<PR>`, `--local`, `--file <path>`, `--json` in addition to `--staged`/`--last-commit`/`--plan`; `argument-hint` is byte-identical to `/lets:review`. PR mode warns on large PRs; `--json` output mirrors `/lets:review --json` (same `verdict`/`tier`/`findings[]` shape, `agent: "check"` + per-finding `lens`, `summary` object). Still no subagent dispatch in any mode. End-of-run box offers the `/lets:review --<flag>` upgrade path.
- **`feat(lets-lq1ud)`** — `/lets:plan --fast`: skips the three subagent-dispatch phases (Step 4 explorers, Step 6 architects, Step 7 experts), replaced with orchestrator-only equivalents. Clarifying questions, checkpoints, discussion, plan format, beads recording all unchanged; Plan Ready output records which mode was used; box gains `/lets:check --plan`.
- **`refactor(lets-ne36e)`** — LETS-box audit across all 17 command files: widths consistent within each file; added the lighter `/lets:check` alternative wherever `/lets:review` was offered alone; CLAUDE.md "Command Output Requirements" gets "Which shortcuts to offer" guidance + a Command Checklist line.
- **`docs`** — `CHANGELOG.md [Unreleased]` updated for the whole batch.

Also closes `lets-afwa4` (ultrathink — already shipped in PR #24) and `lets-ae0wt` (branch-parsing comments — resolved by the `detect-task` skill extraction).

Frontmatter `version` is intentionally left at `0.5.0` (bump-once-per-release — happens at the 0.5.1 ceremony via `scripts/release/bump-version.sh`).

## Verification

- `grep -rn '/lets:pr\b'` → empty (outside historical CHANGELOG entries); `grep -rn 'bd comments list'` → empty
- All LETS boxes across 17 command files + skills + rules: aligned and same-width-within-file (checked with a script)
- `check.md` `argument-hint` byte-equal to `review.md`
- Step renumbering in `start.md` (0-9), `done.md` (1-9, all cross-refs), `plan.md` (1-10) verified consistent
- `git diff` for the rename shows `rename pr.md => github-pr.md (93%)`
- Markdown-only changes (commands/skills/rules/docs) — no code/CLI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)