### PR TITLE
chore: release v0.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lets",
       "source": "./plugins/lets",
       "description": "Development workflow with session management, code review, and task tracking",
-      "version": "0.5.0"
+      "version": "0.5.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-05-11
+
 ### Added
 - README "Recommended scope" note in Install section: project scope is preferred for team-shared repos so teammates inherit `lets` without re-install (lets-i5ayk)
 - `/lets:init` Step 1b: detect plugin install scope from `~/.claude/plugins/installed_plugins.json`; one-time informational notice when scope is `user`, suggesting re-install at project scope. No notice for `project` (best case), `local` (deliberate choice), or `unknown` (dev mode / missing file) (lets-i5ayk)
@@ -325,7 +327,8 @@ Initial release with expert agents team.
 - SessionStart hook injecting workflow rules
 - Plugin structure: commands, agents, hooks
 
-[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.1...HEAD
+[0.5.1]: https://github.com/restarter/lets-workflow/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/restarter/lets-workflow/compare/v0.3.0...v0.5.0
 [0.3.1]: https://github.com/restarter/lets-workflow/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/restarter/lets-workflow/compare/v0.2.4...v0.3.0

--- a/plugins/lets/.claude-plugin/plugin.json
+++ b/plugins/lets/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": {
     "name": "restarter",
     "url": "https://github.com/restarter"

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.5.0
+version: 0.5.1
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->


### PR DESCRIPTION
Phase 1 of the 0.5.1 release: source-tree version bump + CHANGELOG promote.

- `plugins/lets/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `plugins/lets/rules/lets-rules.md` frontmatter: `0.5.0` → `0.5.1`
- `CHANGELOG.md`: `[Unreleased]` → `[0.5.1]` (heading + compare links)
- Gates passed locally: `make test`, `make build`, `verify-versions.sh` ✓

Contents of 0.5.1: the `/lets:*` command-surface batch from #66 (`/lets:pr` → `/lets:github-pr`, `/lets:check` ↔ `/lets:review` param parity, `/lets:plan --fast`, `/lets:done` CHANGELOG step, `/lets:start` rename hint, `bd comments` syntax fix, AUTO MODE plan-visibility gate, LETS-box audit).

After merge: `git checkout main && git pull && make release-tag VERSION=0.5.1` → goreleaser CI publishes the GH Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)