### PR TITLE
chore: release v0.5.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lets",
       "source": "./plugins/lets",
       "description": "Development workflow with session management, code review, and task tracking",
-      "version": "0.5.1"
+      "version": "0.5.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.2] - 2026-05-12
+
 ### Added
 - `/lets:update` command + `lets update` Go subcommand — syncs a project with the current LETS release: self-heals `.lets/.env` (header refresh when `LETS_ENV_VERSION` is stale, user values preserved) and `.claude/rules/lets-rules.md` (re-copy when outdated/missing), and reports version status for the `lets` binary and the Claude Code plugin vs the latest GitHub release (it can't self-replace those, so it prints the upgrade command). GitHub `releases/latest` lookup is cached for 1h at `.lets/cache/update-check.json` with a stale-cache fallback; `--offline` skips the network, `--refresh-cache` bypasses the cache, `--json` emits a machine-readable envelope (`schema_version=1`). Also reports `consistent` (binary == plugin == installed-rules version) to flag partial upgrades. New `cli/internal/updatecmd/` package (lets-hdrdr.3)
 
@@ -346,7 +348,8 @@ Initial release with expert agents team.
 - SessionStart hook injecting workflow rules
 - Plugin structure: commands, agents, hooks
 
-[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.2...HEAD
+[0.5.2]: https://github.com/restarter/lets-workflow/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/restarter/lets-workflow/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/restarter/lets-workflow/compare/v0.3.0...v0.5.0
 [0.3.1]: https://github.com/restarter/lets-workflow/compare/v0.3.0...v0.3.1

--- a/plugins/lets/.claude-plugin/plugin.json
+++ b/plugins/lets/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "author": {
     "name": "restarter",
     "url": "https://github.com/restarter"

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.5.1
+version: 0.5.2
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->


### PR DESCRIPTION
Phase 1 of the v0.5.2 release ceremony (per `RELEASING.md`).

Bumps the source-tree version `0.5.1 → 0.5.2` across the 3 version sources (`plugin.json`, `marketplace.json`, `lets-rules.md` frontmatter) and promotes `CHANGELOG.md` `[Unreleased] → [0.5.2] - 2026-05-12` with bottom-link update.

### What's in 0.5.2

**Added**
- `/lets:update` command + `lets update` Go subcommand (`cli/internal/updatecmd/`) — syncs a project with the current LETS release: self-heals `.lets/.env` + `.claude/rules/lets-rules.md`, version-checks the `lets` binary and plugin vs latest GitHub release, `--offline` / `--refresh-cache` / `--json` (lets-hdrdr.3)

**Changed**
- Rules-drift Notice messages point at `/lets:update` for `unknown`/`outdated`/`ahead`; `/lets:init` only for `missing` (lets-hdrdr.3)
- `lets init` / `/lets:update` restore a hand-deleted `LETS_*` key to its canonical default instead of an empty value (lets-hdrdr.3)
- `/lets:commit` carries `(task-id)` scope in the subject; prefers `/lets:commit` over generic commit skills (lets-4w2sc)
- Internal skills `detect-task` / `actor-fetch-personality` hidden from `/lets:` autocomplete via `user-invocable: false` (lets-4w2sc)
- `LETS_LANGUAGE` documented everywhere as an English language name (lets-ha7sk)
- CLAUDE.md / README docs updates (lets-4w2sc)

**Fixed**
- `lets init` no longer writes `.beads/` to `.gitignore` (lets-4w2sc)
- `lets init` step output distinguishes a no-commits repo from detached HEAD (lets-4w2sc)
- `/lets:start` Step 2 doesn't fail on a repo with no commits (lets-4w2sc)
- `/lets:done` / `/lets:end` session-id capture moved to `$CLAUDE_CODE_SESSION_ID` Bash env var in bash contexts (lets-4w2sc, lets-bdkvd)
- `/lets:init` Step 2b checks `git remote -v` alongside `gh auth status` (lets-4w2sc)

Gates passed locally: `make test`, `make build`, `verify-versions`. Merge → then `make release-tag VERSION=0.5.2` on main triggers `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)