### PR TITLE
Post-repo-public fixes: CI workflow + docs restructure (lets-81q1o)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: CI
+
+# Build + test + lint the Go CLI.
+#
+# Complements verify-versions.yml, which only checks source-tree version
+# coherence (it does NOT compile, run tests, or lint). Together these two
+# workflows are the required status checks on the `main protection` ruleset.
+#
+# Runs on every PR to main and every push to main (the push trigger is
+# defensive — catches breakage if branch protection is ever bypassed).
+#
+# Security: no untrusted user input (PR titles/bodies, commit messages, issue
+# titles) flows into any run: command — only Makefile targets and pinned
+# actions. The only github context value used is github.ref (in the
+# concurrency group), which GitHub validates against allowed ref patterns.
+# Token is read-only (permissions: contents: read), mirroring verify-versions.yml.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  # Cancel superseded runs on a PR (only the latest push matters), but let every
+  # push to main run to completion so each commit on main keeps its own status.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build-test:
+    name: Build, vet & test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'cli/go.mod'          # pins to the `go` directive (1.22)
+          cache-dependency-path: 'cli/go.sum'
+
+      - name: Build
+        run: make build
+
+      - name: Vet
+        run: make vet
+
+      - name: Test
+        run: make test                          # go test -race; ubuntu-latest ships gcc
+
+  lint:
+    # Separate job so it runs in parallel with build-test (golangci-lint-action
+    # docs recommend isolating the linter from `go test` etc.).
+    name: Lint (golangci-lint)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'cli/go.mod'
+          cache-dependency-path: 'cli/go.sum'
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12
+          working-directory: cli

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 .lets/
 /lets/
 .idea/
-AGENTS.md
+/AGENTS.md
 .dolt/
 .beads/hooks/
 *.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,10 @@ cli/                              # Go CLI - companion binary (Phase 2+, lets-7v
 ├── internal/cli/                 #   Cobra command factories (root.go, version.go, *_test.go)
 ├── internal/version/version.go   #   Version (var, ldflags-overridable from git tag)
 ├── go.mod, go.sum
-└── .golangci.yml                 #   Linter config (default + gofmt/goimports/misspell)
+└── .golangci.yml                 #   golangci-lint v2 config (default linters + misspell; gofmt/goimports as formatters)
 Makefile                          # Repo-root build (build/test/vet/lint/fmt/install/clean)
 .editorconfig                     # Editor whitespace/charset settings
+.github/workflows/                # CI: ci.yml (Go build/vet/test/lint on PRs+pushes), verify-versions.yml (source-tree version coherence), release.yml (tag-driven goreleaser)
 scripts/release/                  # Release tooling: bump-version.sh + verify-versions.sh (used by Makefile bump/release-tag)
 scripts/remote/dolt/              # Dolt SQL server VPS deployment + ad-hoc backup (NOT plugin)
 scripts/remote/beads-web/         # beads-web (Rust kanban board) VPS deployment (NOT plugin)
@@ -93,6 +94,10 @@ Phase 1: Bump (manual, on release/X.Y.Z branch)
                                    Prerelease (X.Y.Z-rc.N): 3 files only, CHANGELOG intact
 Phase 2: Review (PR to main)
   .github/workflows/verify-versions.yml: PR-time source-tree coherence check
+  .github/workflows/ci.yml:              PR-time Go build + vet + test + lint
+  (both are required status checks on the `main protection` ruleset; the release
+   PR is gated by them like any other PR — no tag-push CI, the tagged commit is
+   already validated here, and Phase 4's goreleaser cross-builds all 5 platforms)
 Phase 3: Tag (manual, on main)
   make release-tag VERSION=X.Y.Z: tags merge commit + pushes tag
 Phase 4: Distribute (automated, on tag push)

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ help:
 	@echo "  test            - Run cli unit tests with -race (needs CGO + C compiler)"
 	@echo "  test-fast       - Run cli unit tests without -race (no CGO required)"
 	@echo "  vet             - Run go vet"
-	@echo "  lint            - Run golangci-lint (requires it installed)"
+	@echo "  lint            - Run golangci-lint v2 (requires it installed - see cli/README.md)"
 	@echo "  fmt             - Run gofmt -w -s"
 	@echo "  fmt-check       - Verify gofmt is clean (CI use)"
 	@echo "  install         - Install lets to /usr/local/bin (or ~/.local/bin if not writable)"

--- a/README.md
+++ b/README.md
@@ -19,17 +19,16 @@ Claude Code is powerful, but without structure it drifts - forgets context betwe
 
 ## Why LETS
 
-**You don't just chat with AI. You run a dev team.**
+**You don't just chat with AI. You run a process** — `/lets:*` commands and 14 expert agents cover the whole development cycle, every change is reviewed by the right specialists, and every decision is made deliberately, with you in the loop.
 
-- **14 expert agents** that dynamically select themselves based on your code changes - security agent for auth code, database agent for migrations, architect for structural changes. No manual configuration.
-- **Full PR review lifecycle** - agents analyze the PR, you discuss findings, they post inline comments to GitHub, then follow up to verify fixes. Approve or request changes without leaving the terminal.
-- **Actor agent** - load any expert personality from a URL or file. Want a senior iOS developer's perspective on your Swift code? A UX designer reviewing your components? Import their personality and get their unique take on your work.
-- **Structured planning pipeline** - brainstorm ideas (4 modes), plan architecture with codebase exploration, execute with approval gates. Think, design, build.
-- **Agent Teams** - spawn autonomous agents that implement multiple tasks in parallel, each in an isolated worktree with plan approval from the lead.
-- **Session continuity** - context restored automatically, even after compaction. Discovery notes, decisions, and progress survive across conversations.
-- **Task-driven** - every session starts with a task, every commit links to it, tracked via [beads](https://github.com/steveyegge/beads) with shared database for teams via [Dolt](https://github.com/dolthub/dolt).
-- **GitHub-native** - PR creation, inline review comments, follow-up, approval. Or local merge if you prefer.
-- **Latest Claude Code features** - ultrathink for deep analysis, interactive UI for decisions, native plan mode for execution.
+- **A complete workflow, not a chat box.** One loop from start to ship — restore context and pick a task, plan the work, build it, review it, open a PR, close the task. The plugin keeps Claude on the rails the whole way; nothing falls through the cracks.
+- **Plan before you build.** Brainstorm ideas (4 modes), design the architecture with real codebase exploration and expert review, then execute step by step behind approval gates. Choices are made on purpose, not improvised.
+- **Every change reviewed by the right experts.** 14 specialized agents select themselves based on what changed - security for auth code, database for migrations, architect for structure. Findings come tiered (`[BLOCKER]` / `[SUGGESTION]` / `[NIT]`), so you act on what matters. Plus an *actor* agent that loads any expert personality from a URL or file.
+- **You decide, always.** Commit, push, PR, merge - every state-changing step waits for your "go". The AI proposes and explains its reasoning; it never silently switches approach. Transparency by design.
+- **Context that survives.** Tasks, decisions, and discovery notes live in [beads](https://github.com/steveyegge/beads) and outlast conversation compaction and new sessions - pick up exactly where you left off.
+- **Built for teams.** Shared task database via [Dolt](https://github.com/dolthub/dolt), Agent Teams that implement multiple tasks in parallel (each in its own worktree, plan approved by the lead), and worktrees for hands-on parallel sessions.
+- **GitHub-native PR review.** Agents analyze the PR, you discuss findings, they post inline comments to the exact lines, follow up on fixes, approve or request changes - without leaving the terminal.
+- **Built on the latest Claude Code features.** Ultrathink for deep analysis, interactive UI for decisions, native plan mode for execution.
 
 <div align="center">
 
@@ -43,7 +42,7 @@ Claude Code is powerful, but without structure it drifts - forgets context betwe
 
 ### Prerequisites
 
-The plugin requires the `lets` CLI binary on `$PATH` for SessionStart/PreCompact hooks and `lets statusline`.
+The plugin requires the `lets` CLI binary on `$PATH`. It runs the SessionStart/PreCompact hooks, renders the `lets statusline`, and handles rules distribution — `/lets:init` copies the workflow rules into `<project>/.claude/rules/lets-rules.md`, and `/lets:update` re-syncs them as new releases ship.
 
 **One-liner (macOS / Linux):**
 
@@ -99,54 +98,6 @@ Then start working:
 /lets:end            # Save session summary for next time
 ```
 
-## 🔧 How It Works
-
-### Session Lifecycle
-
-```
-/lets:start ─── choose how to work ─── /lets:commit ─── /lets:done ─── /lets:end
-```
-
-**Start** - `/lets:start` restores context from the previous session, shows available tasks, and creates a feature branch. Context survives conversation compaction via beads task comments.
-
-**Choose how to work** - depending on the task, you pick the approach:
-
-```
-┌─ You write code yourself ─────────────────────────────────────────────────┐
-│  Write code with Claude. Use helpers along the way:                       │
-│  /lets:opinion   Technical decision with expert agents                     │
-│  /lets:ask       Quick question to a single expert                        │
-│  /lets:check     Quick sanity check (6 perspectives, ~30s)                │
-│  /lets:review    Full multi-agent code review (~2-3 min)                  │
-│                                                                           │
-├─ You plan, Claude builds ─────────────────────────────────────────────────┤
-│  /lets:brainstorm  Ideation: backlog review, explore ideas, brainstorm    │
-│  /lets:plan        Design how to build it - codebase exploration, arch    │
-│  /lets:execute     Claude implements the plan with your approval gates    │
-│                                                                           │
-├─ Agents work in parallel ─────────────────────────────────────────────────┤
-│  /lets:team        Spawn agents that implement multiple tasks at once     │
-│  /lets:worktree    Open parallel sessions in separate terminals           │
-└───────────────────────────────────────────────────────────────────────────┘
-```
-
-**Commit** - `/lets:commit` reviews changes and creates a conventional commit (`feat:`, `fix:`, `docs:`, …) linked to the active task.
-
-**Finish** - `/lets:done` creates a PR on GitHub (or merges locally). `/lets:end` saves a session summary so the next conversation picks up where you left off.
-
-### Under the Hood
-
-**SessionStart + PreCompact Hooks** - run `lets hook session-start` / `lets hook precompact` on every Claude Code conversation. The hooks emit a small `## LETS Config` block (and a drift notice if rules are out of date) - the workflow rules themselves live in `<project>/.claude/rules/lets-rules.md` (copied there by `/lets:init`, re-synced by `/lets:update` when a new release ships) and Claude Code loads them as project instructions. SessionStart fires on new/resumed/cleared/compacted sessions; PreCompact ensures rules survive long-session compaction. This is what makes Claude follow the LETS workflow without you having to remind it.
-
-**LETS Boxes** - after key actions, Claude shows contextual next-step suggestions so you always know what to do next:
-
-```
-┌─ LETS ─────────────────────────┐
-│  Review?  /lets:review         │
-│  Commit?  /lets:commit         │
-└────────────────────────────────┘
-```
-
 ## 📖 Commands
 
 ### Session & Task
@@ -180,87 +131,14 @@ Then start working:
 | `/lets:opinion` | Technical decision analysis (dynamic expert agents in parallel) |
 | `/lets:ask` | Quick expert consultation (single agent) |
 
-### Setup
+### Init & Update
 
 | Command | Description |
 |---------|-------------|
 | `/lets:init` | Initialize LETS in current project |
 | `/lets:update` | Sync project with the current release - `.lets/.env` + rules self-heal, plus version status for the `lets` binary and the plugin |
 
-## 🔍 Code Review
-
-Three levels of review, from 30-second sanity check to full PR lifecycle:
-
-| Need | Command | Time | What happens |
-|------|---------|------|-------------|
-| Quick pre-commit check | `/lets:check` | ~30s | Inline 6-lens review: bugs, security, performance, quality, compliance, docs |
-| Full code review | `/lets:review` | ~2-3 min | Dynamic agent selection - only relevant experts for your changes |
-| Full PR lifecycle (GitHub) | `/lets:github-pr <PR>` | Interactive | Analyze, discuss, post inline comments, follow up on fixes, approve |
-
-### GitHub PR Review Lifecycle (`/lets:github-pr`)
-
-This is where LETS shines. Instead of reviewing PRs in a browser, you do it from the terminal with expert agents. GitHub only — Bitbucket/local flows aren't implemented (those finish tasks via `/lets:done`):
-
-```
-/lets:github-pr https://github.com/owner/repo/pull/42
-```
-
-1. **Analyze** - agents review the PR based on what actually changed (security agent for auth code, database for migrations, etc.)
-2. **Discuss** - you see each finding with code context, decide what to post: inline comment, summary, or drop
-3. **Post** - batch-posts inline comments to the exact lines on GitHub, with a review summary
-4. **Follow up** - after the author pushes fixes, `/lets:github-pr --follow-up` checks each finding: fixed, not fixed, or needs discussion
-5. **Approve** - `/lets:github-pr --approve` when ready, or request changes
-
-Authors can respond with `/lets:github-pr --respond` - triage comments, auto-fix mechanical issues, post replies.
-
-### Dynamic Agent Selection
-
-Agents aren't hardcoded. Each command analyzes your changes and selects only relevant experts:
-
-- Changed auth code? Security + backend + architect join the review
-- Pure docs update? Docs + compliance, skip the rest
-- Full-stack feature? Up to 12 agents, each focused on their domain
-
-For plan reviews, agents are selected by signals in the plan content (mentions of migrations, API endpoints, Docker configs, etc.).
-
-## 🏗️ Planning
-
-> **Think** → **Design** → **Build**
-
-**Brainstorm** (`/lets:brainstorm`) - 4 modes for different situations:
-- *Review backlog* - agents analyze your task list, find patterns, suggest priorities
-- *Explore ideas* - deep dive into a specific area with codebase analysis
-- *Quick brainstorm* - fast ideation on a topic
-- *Cleanup* - find stale tasks, broken dependencies, forgotten work
-
-**Plan** (`/lets:plan`) - codebase exploration with dynamically-scaled explorer agents, then architecture design with expert evaluation. Small project? One explorer. Large monorepo? Up to 10, each mapping a different area. Want a quick talk-through instead? `/lets:plan --fast` skips the subagent phases and plans collaboratively in-session.
-
-**Execute** (`/lets:execute`) - implements the plan step by step in native plan mode. You approve each step before Claude proceeds. No surprises.
-
-## ⚡ Parallel Work
-
-Two ways to work on multiple tasks at once:
-
-### Agent Teams (autonomous)
-
-Spawn multiple agents that work in parallel, each in an isolated worktree:
-
-```
-/lets:team run    # select tasks, agents start working
-```
-
-Each teammate gets one task, creates a plan, waits for your approval, then implements. Commits are cherry-picked back. Dynamic teammate count - the system scales based on how many tasks you select.
-
-### Worktrees (interactive)
-
-Work on multiple tasks yourself in separate terminals:
-
-```bash
-/lets:worktree create auth-feature    # Terminal 1 (main repo)
-cd .worktrees/auth-feature && claude  # Terminal 2 - start new session
-```
-
-Each worktree gets its own branch, shares the task database and config via symlinks. Full LETS workflow in each terminal.
+→ Flags and when to use which: **[docs/commands.md](docs/commands.md)**.
 
 ## 🤖 Expert Agents
 
@@ -283,17 +161,134 @@ Each worktree gets its own branch, shares the task database and config via symli
 | implementer | Full-stack implementation | Used by `/lets:team` |
 | actor | Any personality from URL or file | On explicit user request |
 
-### How agents work
+Findings are tiered: `[BLOCKER]` (must fix), `[SUGGESTION]` (should fix), `[NIT]` (nice to have) — agents skip the obvious and focus on what matters. They're read-only; the only exception is `implementer`, which has write access for parallel work via `/lets:team`. The `actor` agent loads any expert personality from a URL or file — you confirm each one before it's used.
 
-**Dynamic selection** - you don't pick agents. Commands analyze your changes and select only relevant experts. Security agent won't review a docs-only PR. Database agent won't review CSS.
+### Dynamic Agent Selection
 
-**Tiered scoring** - findings are `[BLOCKER]` (must fix), `[SUGGESTION]` (should fix), or `[NIT]` (nice to have). No noise - agents are trained to skip obvious things and focus on what matters.
+You don't pick agents — each command analyzes your changes and selects only the relevant experts:
 
-**Multiple modes** - each agent operates differently depending on the context: *review* mode for code review, *opinion* mode for technical decisions, *plan* mode for architecture evaluation, *brainstorm* mode for ideation, *ask* mode for direct questions.
+- Changed auth code? Security + backend + architect join the review
+- Pure docs update? Docs + compliance, skip the rest
+- Full-stack feature? Up to 12 agents, each focused on their domain
 
-**Actor agent** - load any expert personality from a URL or local file. Want a senior iOS developer's perspective? A UX designer's take? Import their personality and get their domain-specific analysis. User confirms each personality before loading.
+For plan reviews, agents are selected by signals in the plan content (mentions of migrations, API endpoints, Docker configs, etc.).
 
-**Read-only by default** - agents analyze but never modify code. The only exception: `implementer` has write access for parallel work via `/lets:team`.
+→ Agent modes, tiered scoring, and the actor agent in detail: **[docs/agents.md](docs/agents.md)**.
+
+## 🔧 Using LETS
+
+A LETS session runs a loop: start, work, commit, finish.
+
+```
+/lets:start ─── choose how to work ─── /lets:commit ─── /lets:done ─── /lets:end
+```
+
+**Start** - `/lets:start` restores context from the previous session, shows available tasks, and creates a feature branch. Context survives conversation compaction via beads task comments.
+
+**Choose how to work** - depending on the task, you pick the approach:
+
+```
+┌─ You write code yourself ─────────────────────────────────────────────────┐
+│  Write code with Claude. Use helpers along the way:                       │
+│  /lets:opinion   Technical decision with expert agents                     │
+│  /lets:ask       Quick question to a single expert                        │
+│  /lets:check     Quick sanity check (6 perspectives, ~30s)                │
+│  /lets:review    Full multi-agent code review (~2-3 min)                  │
+│                                                                           │
+├─ You plan, Claude builds ─────────────────────────────────────────────────┤
+│  /lets:brainstorm  Ideation: backlog review, explore ideas, brainstorm    │
+│  /lets:plan        Design how to build it - codebase exploration, arch    │
+│  /lets:execute     Claude implements the plan with your approval gates    │
+│                                                                           │
+├─ Agents work in parallel ─────────────────────────────────────────────────┤
+│  /lets:team        Spawn agents that implement multiple tasks at once     │
+│  /lets:worktree    Open parallel sessions in separate terminals           │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+**Commit** - `/lets:commit` reviews changes and creates a conventional commit (`feat:`, `fix:`, `docs:`, …) linked to the active task.
+
+**Finish** - `/lets:done` creates a PR on GitHub (or merges locally). `/lets:end` saves a session summary so the next conversation picks up where you left off.
+
+→ Full walkthrough: **[docs/workflow.md](docs/workflow.md)**.
+
+### Plan, then build
+
+> **Think** → **Design** → **Build**
+
+**Brainstorm** (`/lets:brainstorm`) - 4 modes for different situations:
+- *Review backlog* - agents analyze your task list, find patterns, suggest priorities
+- *Explore ideas* - deep dive into a specific area with codebase analysis
+- *Quick brainstorm* - fast ideation on a topic
+- *Cleanup* - find stale tasks, broken dependencies, forgotten work
+
+**Plan** (`/lets:plan`) - codebase exploration with dynamically-scaled explorer agents, then architecture design with expert evaluation. Small project? One explorer. Large monorepo? Up to 10, each mapping a different area. Want a quick talk-through instead? `/lets:plan --fast` skips the subagent phases and plans collaboratively in-session.
+
+**Execute** (`/lets:execute`) - implements the plan step by step in native plan mode. You approve each step before Claude proceeds. No surprises.
+
+→ More: **[docs/plan-execute.md](docs/plan-execute.md)**.
+
+### Code review
+
+Three levels of review, from 30-second sanity check to full PR lifecycle:
+
+| Need | Command | Time | What happens |
+|------|---------|------|-------------|
+| Quick pre-commit check | `/lets:check` | ~30s | Inline 6-lens review: bugs, security, performance, quality, compliance, docs |
+| Full code review | `/lets:review` | ~2-3 min | Dynamic agent selection - only relevant experts for your changes |
+| Full PR lifecycle (GitHub) | `/lets:github-pr <PR>` | Interactive | Analyze, discuss, post inline comments, follow up on fixes, approve |
+
+#### GitHub PR Review Lifecycle (`/lets:github-pr`)
+
+This is where LETS shines. Instead of reviewing PRs in a browser, you do it from the terminal with expert agents. GitHub only — Bitbucket/local flows aren't implemented (those finish tasks via `/lets:done`):
+
+```
+/lets:github-pr https://github.com/owner/repo/pull/42
+```
+
+1. **Analyze** - agents review the PR based on what actually changed (security agent for auth code, database for migrations, etc.)
+2. **Discuss** - you see each finding with code context, decide what to post: inline comment, summary, or drop
+3. **Post** - batch-posts inline comments to the exact lines on GitHub, with a review summary
+4. **Follow up** - after the author pushes fixes, `/lets:github-pr --follow-up` checks each finding: fixed, not fixed, or needs discussion
+5. **Approve** - `/lets:github-pr --approve` when ready, or request changes
+
+Authors can respond with `/lets:github-pr --respond` - triage comments, auto-fix mechanical issues, post replies.
+
+→ More: **[docs/code-review.md](docs/code-review.md)**.
+
+### Working in parallel
+
+Two ways to work on multiple tasks at once:
+
+**Agent Teams (autonomous)** — spawn multiple agents that work in parallel, each in an isolated worktree:
+
+```
+/lets:team run    # select tasks, agents start working
+```
+
+Each teammate gets one task, creates a plan, waits for your approval, then implements. Commits are cherry-picked back. Dynamic teammate count - the system scales based on how many tasks you select.
+
+**Worktrees (interactive)** — work on multiple tasks yourself in separate terminals:
+
+```bash
+/lets:worktree create auth-feature    # Terminal 1 (main repo)
+cd .worktrees/auth-feature && claude  # Terminal 2 - start new session
+```
+
+Each worktree gets its own branch, shares the task database and config via symlinks. Full LETS workflow in each terminal.
+
+→ More: **[docs/parallel-work.md](docs/parallel-work.md)**.
+
+### LETS Help Boxes
+
+After key actions, Claude shows a contextual help box with the most likely next steps, so you always know what to do next:
+
+```
+┌─ LETS ─────────────────────────┐
+│  Review?  /lets:review         │
+│  Commit?  /lets:commit         │
+└────────────────────────────────┘
+```
 
 ## 📋 Task Integration
 
@@ -303,6 +298,8 @@ LETS uses [beads](https://github.com/steveyegge/beads) for persistent task track
 - Discovery notes and decisions are saved as task comments - they survive context window limits
 - Task dependencies and blocking tracked - `/lets:status` shows what's ready to work on
 - Multi-developer: shared task database via [Dolt](https://github.com/dolthub/dolt) remotes - everyone sees the same backlog
+
+→ The task lifecycle, creating/taking tasks, beads memory: **[docs/tasks.md](docs/tasks.md)**.
 
 ## ⚙️ Configuration
 
@@ -322,33 +319,9 @@ LETS_PR_FLOW=github
 LETS_TRACKER=beads
 ```
 
-> **Migration from legacy `config.yaml`:** if your project still has `.lets/config.yaml`, run `/lets:init` — `lets init` migrates it to `.lets/.env` (preserving values via allowlist regex). The yaml file is kept for reference but no longer read.
+All plugin-generated files live under `.lets/` (gitignored); interactive worktrees under `.worktrees/`.
 
-## File Storage
-
-All generated files go to `.lets/` (gitignored):
-
-```
-.lets/.env              Project settings (LETS_LANGUAGE, LETS_MERGE_BRANCH, LETS_PR_FLOW, LETS_TRACKER)
-.lets/sessions/         Session summaries and start references
-.lets/reviews/          Saved review reports
-.lets/plans/            Implementation plans
-.lets/execution/        PR review state and team records
-.lets/cache/            Usage stats and cached data
-```
-
-Interactive worktrees are stored in `.worktrees/` (gitignored).
-
-> **Note:** LETS requires the [beads](https://github.com/steveyegge/beads) plugin for task tracking. See its [install docs](https://github.com/steveyegge/beads#installation) — typically `curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash`.
-
-## Setup order: `lets init` and `bd init`
-
-Run `/lets:init` first, then enable beads (`/lets:init` will run `bd init` for you if both binaries are installed; you can also run `bd init` manually afterwards). Order matters and the two tools touch different files:
-
-- **`lets init` (the plugin's CLI)** writes only LETS-owned `.gitignore` entries — `.lets/` and `.worktrees/`. It also creates `.lets/.env`, `.lets/.env.example`, the `.lets/{sessions,reviews,plans,execution,cache}/` layout, copies `.claude/rules/lets-rules.md`, and sets the statusline in `.claude/settings.json`.
-- **`bd init` (beads)** adds its own entries to `.gitignore` (`.beads/...`, `issues.jsonl`, `.beads-credential-key`), installs a project-scoped SessionStart + PreCompact hook block into `.claude/settings.json`, and creates `CLAUDE.md` / `AGENTS.md` if they don't exist yet.
-- **PreCompact hook duplication:** bd's project-scoped PreCompact hook runs in addition to the plugin's plugin-scoped one — both fire on the same event. Not destructive, but rules get injected twice. Tracked under `lets-71urx`; until that lands, this is a known integration quirk, not a configuration error.
-- **`bd init --server --database=NAME`** may auto-create the database on first connect if the SQL user has CREATE privilege (depends on Dolt server policy). The remote dolt deployment docs in `scripts/remote/dolt/README.md` cover the multi-checkout safety mechanism (`PROJECT IDENTITY MISMATCH`) you'll meet on a second machine.
+→ Every setting, the full `.lets/` layout, and the `lets init` / `bd init` setup order: **[docs/configuration.md](docs/configuration.md)**.
 
 ## 📦 Dependencies
 
@@ -359,6 +332,24 @@ Run `/lets:init` first, then enable beads (`/lets:init` will run `bd init` for y
 | [beads](https://github.com/steveyegge/beads) | Yes | Task tracking and issue management (Claude Code plugin) |
 | [gh](https://cli.github.com/) | Optional | GitHub PR workflow (when `LETS_PR_FLOW=github`) |
 | [jq](https://jqlang.github.io/jq/) | Optional | Statusline JSON parsing |
+
+## 📚 Documentation
+
+The README is the tour; **[docs/](docs/)** is the manual.
+
+| Doc | What's in it |
+|-----|--------------|
+| [installation.md](docs/installation.md) | Install the `lets` binary and the Claude Code plugin, initialize a project. Troubleshooting and uninstall. |
+| [workflow.md](docs/workflow.md) | The day-to-day loop — session lifecycle, the three ways to work, LETS boxes, how the hooks keep Claude on track. |
+| [plan-execute.md](docs/plan-execute.md) | The plan → execute flow — `/lets:plan` designs the change with codebase exploration and expert review, `/lets:execute` implements it behind approval gates. |
+| [code-review.md](docs/code-review.md) | Three levels of review — `/lets:check`, `/lets:review`, and `/lets:github-pr` (analyze, post inline, follow up, approve). Dynamic agent selection. |
+| [agents.md](docs/agents.md) | The 14 expert agents, what triggers each, tiered scoring, agent modes, and the actor agent. |
+| [parallel-work.md](docs/parallel-work.md) | Working on several tasks at once — `/lets:team` (autonomous agents) and `/lets:worktree` (parallel terminals). |
+| [tasks.md](docs/tasks.md) | Task tracking with beads — the task lifecycle, taking and creating tasks, notes, `/lets:brainstorm`, beads memory, shared backlogs for teams. |
+| [commands.md](docs/commands.md) | Full reference for every `/lets:*` command. |
+| [configuration.md](docs/configuration.md) | `.lets/.env` settings, the `.lets/` file layout, `lets init` vs `bd init` setup order, and dependencies. |
+
+Building on the plugin itself? See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`CLAUDE.md`](CLAUDE.md).
 
 ## License
 

--- a/cli/.golangci.yml
+++ b/cli/.golangci.yml
@@ -1,29 +1,34 @@
-# golangci-lint config for lets CLI
-# https://golangci-lint.run/usage/configuration/
+# golangci-lint v2 config for the lets CLI.
+# https://golangci-lint.run/
+#
+# CI runs golangci-lint v2.x via golangci/golangci-lint-action
+# (see .github/workflows/ci.yml). Install a v2.x golangci-lint locally
+# (`make lint`) for results that match CI — a v1.x binary will reject this file.
 
-run:
-  timeout: 3m
+version: "2"
 
 linters:
+  # errcheck, govet, ineffassign, staticcheck, unused are the v2 default set —
+  # listed explicitly for clarity. gosimple/stylecheck were folded into
+  # staticcheck in v2, so they're no longer separate entries.
   enable:
-    # Default linters (explicit for clarity)
     - errcheck       # Unchecked errors
-    - gosimple       # Code simplifications
     - govet          # Stricter than `go vet`
     - ineffassign    # Unused assignments
-    - staticcheck    # Static analysis
+    - staticcheck    # Static analysis (includes former gosimple/stylecheck)
     - unused         # Unused vars/funcs
-    # Additional
+    - misspell       # Common misspellings
+  settings:
+    errcheck:
+      # cobra commands write via cmd.OutOrStdout() (io.Writer); errors from
+      # fmt.F*print* to that surface are not actionable - same rationale as
+      # the default exclusion of fmt.Print*.
+      exclude-functions:
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - fmt.Fprint
+
+formatters:
+  enable:
     - gofmt          # Format check
     - goimports      # Import sorting/grouping
-    - misspell       # Common misspellings
-
-linters-settings:
-  errcheck:
-    # cobra commands write via cmd.OutOrStdout() (io.Writer); errors from
-    # fmt.F*print* to that surface are not actionable - same rationale as
-    # the default exclusion of fmt.Print*.
-    exclude-functions:
-      - fmt.Fprintf
-      - fmt.Fprintln
-      - fmt.Fprint

--- a/cli/README.md
+++ b/cli/README.md
@@ -44,7 +44,7 @@ make install-go  # alternative: `go install` to $GOBIN (Go-standard layout)
 make clean       # removes built artifact + test cache
 ```
 
-`make lint` requires golangci-lint installed: `brew install golangci-lint` or `go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest`.
+`make lint` requires golangci-lint **v2** installed (the config in `cli/.golangci.yml` is v2-format - a v1 binary rejects it): `brew install golangci-lint` or `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`. CI runs the same lint via `golangci/golangci-lint-action` (see `.github/workflows/ci.yml`).
 
 `make test` uses `-race`, which requires CGO and a C compiler (clang on macOS via Xcode CLT, gcc on Linux). Fails with linker errors if `CGO_ENABLED=0` or no C toolchain - use `make test-fast` instead.
 

--- a/cli/internal/frontmatter/frontmatter.go
+++ b/cli/internal/frontmatter/frontmatter.go
@@ -23,7 +23,7 @@ func ReadVersion(path string) string {
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	if !scanner.Scan() {

--- a/cli/internal/hook/sessionstart/sessionstart.go
+++ b/cli/internal/hook/sessionstart/sessionstart.go
@@ -122,6 +122,6 @@ func readEnvFile(path string) (map[string]string, error) {
 	if err != nil {
 		return map[string]string{}, err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	return envfile.Parse(f)
 }

--- a/cli/internal/initcmd/jsonmerge.go
+++ b/cli/internal/initcmd/jsonmerge.go
@@ -74,17 +74,17 @@ func AtomicWriteBytes(path string, data []byte, defaultMode os.FileMode) error {
 		return err
 	}
 	tmpPath := tmp.Name()
-	defer os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if err := tmp.Chmod(mode); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if err := tmp.Sync(); err != nil {
-		tmp.Close()
+		_ = tmp.Close()
 		return err
 	}
 	if err := tmp.Close(); err != nil {

--- a/cli/internal/initcmd/migrate_test.go
+++ b/cli/internal/initcmd/migrate_test.go
@@ -58,7 +58,9 @@ func TestParseLegacyYaml_RefusesBlockScalar(t *testing.T) {
 func TestMigrateStatuslineSh_DeletesShim(t *testing.T) {
 	tmp := t.TempDir()
 	letsDir := filepath.Join(tmp, ".lets")
-	os.MkdirAll(letsDir, 0o755)
+	if err := os.MkdirAll(letsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	shimPath := filepath.Join(letsDir, "statusline.sh")
 	if err := os.WriteFile(shimPath, embeddedStatuslineShim, 0o755); err != nil {
 		t.Fatal(err)
@@ -83,7 +85,9 @@ func TestMigrateStatuslineSh_DeletesLegacyBash(t *testing.T) {
 	// while users stay on broken bash.
 	tmp := t.TempDir()
 	letsDir := filepath.Join(tmp, ".lets")
-	os.MkdirAll(letsDir, 0o755)
+	if err := os.MkdirAll(letsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	shimPath := filepath.Join(letsDir, "statusline.sh")
 	// Reuses makeLegacyBash from state_test.go (same package).
 	if err := os.WriteFile(shimPath, makeLegacyBash(), 0o755); err != nil {
@@ -104,7 +108,9 @@ func TestMigrateStatuslineSh_DeletesLegacyBash(t *testing.T) {
 func TestMigrateStatuslineSh_PreservesForeign(t *testing.T) {
 	tmp := t.TempDir()
 	letsDir := filepath.Join(tmp, ".lets")
-	os.MkdirAll(letsDir, 0o755)
+	if err := os.MkdirAll(letsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	shimPath := filepath.Join(letsDir, "statusline.sh")
 	custom := []byte("#!/bin/bash\necho 'my custom thing'\n")
 	if err := os.WriteFile(shimPath, custom, 0o755); err != nil {
@@ -125,7 +131,9 @@ func TestMigrateStatuslineSh_PreservesForeign(t *testing.T) {
 func TestMigrateYamlToEnv(t *testing.T) {
 	tmp := t.TempDir()
 	letsDir := filepath.Join(tmp, ".lets")
-	os.MkdirAll(letsDir, 0o755)
+	if err := os.MkdirAll(letsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	yamlPath := filepath.Join(letsDir, "config.yaml")
 	if err := os.WriteFile(yamlPath, []byte("language: Ukrainian\nmerge-branch: main\ngithub: false\n"), 0o644); err != nil {
 		t.Fatal(err)
@@ -161,7 +169,9 @@ func TestMigrateYamlToEnv_OrphanCleanupWhenEnvExists(t *testing.T) {
 	// as a migration-related action (StepMigrate).
 	tmp := t.TempDir()
 	letsDir := filepath.Join(tmp, ".lets")
-	os.MkdirAll(letsDir, 0o755)
+	if err := os.MkdirAll(letsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	envPath := filepath.Join(letsDir, ".env")
 	envContent := "LETS_LANGUAGE=English\n# already here\n"
 	if err := os.WriteFile(envPath, []byte(envContent), 0o644); err != nil {

--- a/cli/internal/statusline/fetch.go
+++ b/cli/internal/statusline/fetch.go
@@ -131,7 +131,7 @@ func fetchUsage(token string) (usage, error) {
 	if err != nil {
 		return usage{}, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return usage{}, fmt.Errorf("api status %d", resp.StatusCode)
 	}

--- a/cli/internal/statusline/usage.go
+++ b/cli/internal/statusline/usage.go
@@ -43,7 +43,7 @@ func readUsageCache(path string) usage {
 	if err != nil {
 		return u
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	if info, err := f.Stat(); err == nil {
 		u.mtime = info.ModTime()
@@ -108,8 +108,8 @@ func writeUsageCache(path string, u usage) error {
 	}
 	tmp := f.Name()
 	cleanup := func() {
-		f.Close()
-		os.Remove(tmp)
+		_ = f.Close()
+		_ = os.Remove(tmp)
 	}
 	// CreateTemp on POSIX defaults to 0o600; explicit Chmod for portability.
 	if err := os.Chmod(tmp, 0o600); err != nil {
@@ -135,7 +135,7 @@ func writeUsageCache(path string, u usage) error {
 		return err
 	}
 	if err := f.Close(); err != nil {
-		os.Remove(tmp)
+		_ = os.Remove(tmp)
 		return err
 	}
 	return os.Rename(tmp, path)

--- a/cli/internal/updatecmd/latest.go
+++ b/cli/internal/updatecmd/latest.go
@@ -98,7 +98,7 @@ func fetchFromGitHub(ctx context.Context) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("github releases API: %s", resp.Status)
 	}

--- a/cli/internal/updatecmd/pluginversion_test.go
+++ b/cli/internal/updatecmd/pluginversion_test.go
@@ -27,7 +27,7 @@ func TestReadPluginVersion(t *testing.T) {
 		{"no version key", `{"name":"lets"}`, "", true},
 		{"malformed json", `{not json`, "", true},
 		{"non-semver sentinel", `{"version":"unknown"}`, "", true},
-		{"version with control chars", "{\"version\":\"1.0.0]0;x\"}", "", true},
+		{"version with control chars", "{\"version\":\"1.0.0\x1b]0;x\a\"}", "", true},
 		{"missing file", "", "", false},
 	}
 	for _, tc := range cases {

--- a/cli/internal/updatecmd/updatecmd.go
+++ b/cli/internal/updatecmd/updatecmd.go
@@ -125,12 +125,12 @@ func Run(ctx context.Context, opts Options, projectRoot, pluginRoot string) (Res
 // versionArtifact builds an Artifact for a version-only artifact (binary, plugin).
 func versionArtifact(name, current string, latest LatestInfo, latestErr error, offline bool, action string) Artifact {
 	a := Artifact{Name: name, CurrentVersion: current}
-	switch {
-	case current == "":
+	switch current {
+	case "":
 		a.Status = StatusUnknown
 		a.Detail = "could not determine installed version"
 		return a
-	case current == "dev":
+	case "dev":
 		a.Status = StatusDev
 		a.Detail = "untagged dev build - no release comparison"
 		return a

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,17 @@
+# LETS documentation
+
+Reference docs for the LETS Workflow plugin. If you haven't set it up yet, start with **[installation](installation.md)**; for the day-to-day loop, **[workflow](workflow.md)**.
+
+| Doc | What's in it |
+|-----|--------------|
+| [installation.md](installation.md) | Install the `lets` binary and the Claude Code plugin, initialize a project. Troubleshooting and uninstall. |
+| [workflow.md](workflow.md) | The day-to-day loop — session lifecycle, the three ways to work (you code / you plan & Claude builds / agents in parallel), LETS boxes, and how the hooks keep Claude on track. |
+| [plan-execute.md](plan-execute.md) | The plan → execute flow — `/lets:plan` designs the change with codebase exploration and expert review, `/lets:execute` implements it step by step behind approval gates. |
+| [code-review.md](code-review.md) | Three levels of review — `/lets:check` (30s sanity check), `/lets:review` (full multi-agent), `/lets:github-pr` (PR lifecycle: analyze, post inline, follow up, approve). Dynamic agent selection. |
+| [agents.md](agents.md) | The 14 expert agents, what triggers each, tiered scoring, agent modes, and the actor agent (load any personality from a URL or file). |
+| [parallel-work.md](parallel-work.md) | Working on several tasks at once — `/lets:team` (autonomous agents, one task each, isolated worktrees) and `/lets:worktree` (you, in parallel terminals). |
+| [tasks.md](tasks.md) | Task tracking with beads — why it's there, the task lifecycle, taking and creating tasks, notes, `/lets:brainstorm`, beads memory, and shared backlogs for teams. |
+| [commands.md](commands.md) | Full reference for every `/lets:*` command — flags, when to use which. |
+| [configuration.md](configuration.md) | `.lets/.env` settings, the `.lets/` file layout, `lets init` vs `bd init` setup order, and dependencies. |
+
+Building on the plugin itself? See [`CONTRIBUTING.md`](../CONTRIBUTING.md) and [`CLAUDE.md`](../CLAUDE.md) at the repo root.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,45 @@
+# Expert agents
+
+LETS ships 14 specialized agents. You don't pick them — the commands that use agents (`/lets:review`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:brainstorm`, `/lets:team`) analyze the situation and select only the ones that fit.
+
+| Agent | Expertise | Example trigger |
+|-------|-----------|-----------------|
+| architect | System design, patterns, SOLID | Structural changes over ~50 lines |
+| backend | APIs, business logic, error handling | Controllers, services, routes |
+| frontend | UI components, state, accessibility | JS / TS / CSS changes |
+| security | Vulnerabilities, auth, crypto | Auth code, tokens, encryption |
+| database | Schema, migrations, query optimization | Migrations, ORM, raw queries |
+| devops | Docker, CI/CD, deployment | Dockerfiles, CI configs, shell scripts |
+| qa | Test strategy, coverage, assertions | Test files, testing patterns |
+| compliance | Project standards, conventions | Always included in reviews |
+| docs | Documentation sync, README accuracy | Always included in reviews |
+| pragmatist | ROI analysis, overengineering detection | Large changes (over ~200 lines) |
+| git-historian | Blame analysis, change patterns | Changes to existing code |
+| explorer | Codebase mapping, pattern discovery | Used during `/lets:plan` |
+| implementer | Full-stack implementation | Used by `/lets:team` |
+| actor | Any personality from a URL or file | On explicit request |
+
+## How agents work
+
+**Dynamic selection.** Commands analyze the change (or the plan, or the question) and select only the relevant experts. The security agent won't review a docs-only PR; the database agent won't review CSS.
+
+**Tiered scoring.** Findings are `[BLOCKER]` (must fix), `[SUGGESTION]` (should fix), or `[NIT]` (nice to have). Agents are tuned to skip the obvious and focus on what matters — no noise.
+
+**Multiple modes.** Each agent behaves differently depending on context: *review* mode for code review, *opinion* mode for technical decisions, *plan* mode for evaluating an architecture, *brainstorm* mode for ideation, *ask* mode for a direct question.
+
+**Read-only by default.** Agents analyze; they never modify code. The one exception is `implementer`, which has write access for parallel implementation via `/lets:team`.
+
+**Agents respond in English.** Commands localize their output to your language (set by `LETS_LANGUAGE` — see [configuration.md](configuration.md)); the agents themselves always work in English.
+
+## The actor agent
+
+`actor` is a meta-agent: give it a personality — a URL or a local file — and it adopts that persona, then operates with LETS's structured output. Want a senior iOS developer's take on your Swift code? A UX designer reviewing your components? Point it at their personality and get their domain-specific analysis.
+
+It's never auto-selected — it needs an explicit request and a personality source. You confirm each personality before it's loaded.
+
+## See also
+
+- **[code-review.md](code-review.md)** — agents in `/lets:review` and `/lets:github-pr`
+- **[plan-execute.md](plan-execute.md)** — explorer and expert agents in `/lets:plan`
+- **[parallel-work.md](parallel-work.md)** — the `implementer` agent in `/lets:team`
+- **[commands.md](commands.md)** — `/lets:opinion` and `/lets:ask` for decisions and questions

--- a/docs/code-review.md
+++ b/docs/code-review.md
@@ -1,0 +1,67 @@
+# Code review
+
+LETS has three levels of review, from a 30-second sanity check to a full PR lifecycle.
+
+| Need | Command | Time | What happens |
+|------|---------|------|--------------|
+| Quick pre-commit check | `/lets:check` | ~30s | Inline 6-lens review: bugs, security, performance, quality, project conventions, docs. No subagents. |
+| Full code review | `/lets:review` | ~2-3 min | Dynamic agent selection — only the experts relevant to your changes. |
+| Full PR lifecycle (GitHub) | `/lets:github-pr <PR>` | Interactive | Analyze, discuss, post inline comments, follow up on fixes, approve. |
+
+Both `/lets:check` and `/lets:review` accept the same targets: working tree (default), staged changes, last commit, a PR, a specific file (`--file <path>`), or a plan (`--plan`).
+
+**Rule of thumb:** small change → `/lets:check` → commit. Significant change → `/lets:check` → `/lets:review --local` → fix → commit → PR. PR already open → `/lets:review <PR>`, or the full `/lets:github-pr` lifecycle.
+
+## `/lets:check` — quick sanity check
+
+A fast inline pass before you commit. Six perspectives — bugs, security, performance, quality, project conventions, docs — no subagents, ~30 seconds. It's the lighter version of `/lets:review`, with the same target flags. Run it before any commit, or as a first pass on a PR.
+
+## `/lets:review` — full code review
+
+A deep multi-agent review. The command analyzes what actually changed and brings in only the relevant experts — the security agent for auth code, the database agent for migrations, the architect for structural changes. A pure docs update gets docs + compliance and skips the rest; a full-stack feature can pull in up to 12 agents, each focused on its domain.
+
+Findings come back tiered:
+
+- `[BLOCKER]` — must fix
+- `[SUGGESTION]` — should fix
+- `[NIT]` — nice to have
+
+Agents are tuned to skip the obvious and focus on what matters — the goal is signal, not a wall of nitpicks.
+
+For plan reviews (`/lets:review --plan`), agents are selected from signals in the plan content (mentions of migrations, API endpoints, Docker configs, …).
+
+See **[agents.md](agents.md)** for the agent roster and how selection works.
+
+## `/lets:github-pr` — the PR lifecycle
+
+This is where LETS shines: reviewing a PR from the terminal with expert agents instead of in a browser. GitHub only — Bitbucket and local flows finish tasks with `/lets:done` and don't have a PR review lifecycle.
+
+```
+/lets:github-pr https://github.com/owner/repo/pull/42
+```
+
+1. **Analyze** — agents review the PR based on what changed (security agent for auth code, database for migrations, …).
+2. **Discuss** — you see each finding with its code context and decide what to do with it: post it as an inline comment, fold it into the summary, or drop it.
+3. **Post** — batch-posts the inline comments to the exact lines on GitHub, with a review summary.
+4. **Follow up** — after the author pushes fixes, `/lets:github-pr --follow-up` checks each finding: fixed, not fixed, or needs discussion.
+5. **Approve** — `/lets:github-pr --approve` when it's ready, or request changes.
+
+### Responding to a review
+
+If you're the PR author, `/lets:github-pr --respond <PR>` triages the comments on your PR, auto-fixes the mechanical ones, and posts replies.
+
+## Dynamic agent selection
+
+Agents aren't hardcoded into a review. Each command looks at your changes and picks only the relevant experts:
+
+- Changed auth code? Security + backend + architect join.
+- Pure docs update? Docs + compliance, nothing else.
+- Full-stack feature? Up to 12 agents, each on their domain.
+
+The same idea applies to plan reviews — agents are chosen from signals in the plan text.
+
+## See also
+
+- **[agents.md](agents.md)** — the 14 agents and what triggers each
+- **[plan-execute.md](plan-execute.md)** — reviewing a plan before executing it
+- **[commands.md](commands.md)** — `/lets:check`, `/lets:review`, `/lets:github-pr` flags

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,59 @@
+# Command reference
+
+Every `/lets:*` command, grouped. For the day-to-day flow see **[workflow.md](workflow.md)**.
+
+## Session & task
+
+| Command | What it does |
+|---------|--------------|
+| `/lets:start` | Start a session — restore context, show tasks, create a feature branch. `/lets:start <task-id>` jumps to a task; `/lets:start --continue` resumes the in-progress one. |
+| `/lets:end` | End the session — save progress, sync the task tracker, write a summary for next time. |
+| `/lets:commit` | Commit changes — review, conventional commit message, task ID in the scope and a `Task:` footer. Use this instead of `git commit`. Also auto-triggers on "commit" in conversation. |
+| `/lets:done` | Finish the task — push the branch and open a PR (GitHub mode), or merge locally and close the task (local/bitbucket). |
+| `/lets:status` | Task overview and project status — ready, in progress, blocked, recent activity. |
+| `/lets:note` | Add a note to the active task — a decision, gotcha, fact, or reference. |
+
+See **[tasks.md](tasks.md)** for the task lifecycle.
+
+## Planning & execution
+
+| Command | What it does |
+|---------|--------------|
+| `/lets:brainstorm` | Interactive ideation — review the backlog, explore an idea, quick brainstorm, or cleanup. |
+| `/lets:plan` | Structured planning — codebase exploration with scaled explorer agents, then architecture design with expert evaluation, then a written plan in `.lets/plans/`. `--fast` skips the subagent phases and plans in-conversation. |
+| `/lets:execute` | Execute the plan from `/lets:plan` in native plan mode, with your approval at each step. |
+| `/lets:team` | Parallel implementation with Agent Teams — `run` (pick tasks, spawn teammates), `status`, `stop`. |
+| `/lets:worktree` | Create and manage worktrees for parallel sessions — `create <name>`, `list`, `remove <name>`. |
+
+See **[plan-execute.md](plan-execute.md)** and **[parallel-work.md](parallel-work.md)**.
+
+## Review & analysis
+
+| Command | What it does |
+|---------|--------------|
+| `/lets:check` | Quick inline sanity check (~30s) — 6 perspectives, no subagents. Targets: working tree, staged, last commit, a PR, `--file <path>`, `--plan`. |
+| `/lets:review` | Full code review (~2-3 min) — dynamic agent selection. Same targets as `/lets:check`; `--local` for local changes, `<PR>` for a PR, `--plan` for a plan. |
+| `/lets:github-pr` | GitHub PR review lifecycle — `<PR>` to analyze and discuss, then post inline; `--follow-up` to check fixes; `--approve` to approve; `--respond <PR>` for the PR author. |
+| `/lets:opinion` | Technical decision analyzed by expert agents in parallel, with a recommendation. Dynamic agent count. |
+| `/lets:ask` | Quick consultation with a single expert agent — like pinging a colleague. |
+
+See **[code-review.md](code-review.md)** and **[agents.md](agents.md)**.
+
+## Setup
+
+| Command | What it does |
+|---------|--------------|
+| `/lets:init` | Initialize LETS in the current project — creates `.lets/`, writes `.lets/.env` with defaults, copies the workflow rules to `.claude/rules/lets-rules.md`, wires up the statusline, and runs `bd init` if beads is installed. Re-run anytime to self-heal drift or change config. |
+| `/lets:update` | Sync the project with the current release — self-heal `.lets/.env` and the rules file, and report version status for the `lets` binary and the plugin. |
+
+See **[installation.md](installation.md)** and **[configuration.md](configuration.md)**.
+
+## Lighter alternatives
+
+Some commands have a faster, lower-cost counterpart — reach for the light one first:
+
+| Heavy | Lighter |
+|-------|---------|
+| `/lets:review` | `/lets:check` |
+| `/lets:review --plan` | `/lets:check --plan` |
+| `/lets:opinion` | `/lets:ask` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,86 @@
+# Configuration
+
+## `.lets/.env` — project settings
+
+`/lets:init` creates `.lets/.env` with sensible defaults. Edit it to change behavior:
+
+```env
+# Default response language — write the English name, like every value here
+# (English, Ukrainian, Russian, Japanese, ...)
+LETS_LANGUAGE=English
+
+# Target branch for merges and PR base
+LETS_MERGE_BRANCH=main
+
+# PR flow: github | bitbucket | local
+LETS_PR_FLOW=github
+
+# Task tracker (currently: beads)
+LETS_TRACKER=beads
+```
+
+| Key | Purpose |
+|-----|---------|
+| `LETS_LANGUAGE` | The language Claude responds in when it isn't clear from your message. An English language name (`English`, `Ukrainian`, `Japanese`, …) regardless of the script it's written in. |
+| `LETS_MERGE_BRANCH` | The branch tasks merge into and PRs target. Used wherever LETS would otherwise assume `main`. |
+| `LETS_PR_FLOW` | `github` — `/lets:done` pushes and opens a PR via `gh`. `bitbucket` — planned. `local` — no PR; `/lets:done` merges locally. |
+| `LETS_TRACKER` | The task tracker. Currently `beads`. (The schema is reserved for future trackers; today everything calls `bd` regardless.) |
+
+The first line of the file is `LETS_ENV_VERSION` — that's metadata (which `lets` version last wrote the file), not something you set. Keys you add yourself are preserved across `/lets:init` and `/lets:update`, kept under a `# User-added keys` separator.
+
+> **Not for secrets.** The SessionStart hook injects the `LETS_*` values from this file into Claude's context every session, and the file is world-readable on disk. GitHub auth goes through `gh auth login`; other secrets belong in your OS keychain or a tool-specific credential file (for example `.beads/.env` for beads).
+
+> **Migrating from `config.yaml`:** if a project still has `.lets/config.yaml` from an older version, `/lets:init` migrates it to `.lets/.env`. The yaml file is left in place for reference but no longer read.
+
+## File layout
+
+Everything LETS generates lives under `.lets/` (gitignored):
+
+```
+.lets/.env              Project settings (the keys above)
+.lets/.env.example      Reference defaults (regenerated each `lets init`)
+.lets/sessions/         Session summaries and start references
+.lets/reviews/          Saved review reports
+.lets/plans/            Implementation plans from /lets:plan
+.lets/execution/        PR review state and team records
+.lets/cache/            Usage stats and cached data
+```
+
+Interactive worktrees live in `.worktrees/` at the project root (also gitignored).
+
+The workflow rules are the exception — they live outside `.lets/` because they're part of Claude Code's project-instructions channel:
+
+```
+.claude/rules/lets-rules.md   Workflow rules — copied from the plugin by /lets:init, re-synced by /lets:update
+```
+
+Don't edit `.claude/rules/lets-rules.md` by hand — it's a managed copy, and `/lets:init` / `/lets:update` will rewrite it on the next sync. (If you're customizing the plugin itself, edit `plugins/lets/rules/lets-rules.md` instead — see [`CONTRIBUTING.md`](../CONTRIBUTING.md).)
+
+## Setup order: `lets init`, then `bd init`
+
+Run `/lets:init` first — it'll run `bd init` for you if both `lets` and `bd` are on `$PATH`; you can also run `bd init` manually afterwards. The two tools touch different files:
+
+- **`lets init`** writes only LETS-owned `.gitignore` entries (`.lets/`, `.worktrees/`), creates the `.lets/` layout and `.lets/.env`, copies `.claude/rules/lets-rules.md`, and sets the statusline in `.claude/settings.json`.
+- **`bd init`** adds its own `.gitignore` entries (`.beads/...`, `issues.jsonl`, `.beads-credential-key`), installs a project-scoped SessionStart + PreCompact hook block into `.claude/settings.json`, and creates `CLAUDE.md` / `AGENTS.md` if they don't exist yet.
+
+> **Known quirk:** bd's project-scoped PreCompact hook runs in addition to the plugin's, so on a compaction the rules get injected twice. Harmless — being tracked for a fix.
+
+For a shared task database across a team, `bd init --server --database=<name>` connects to a Dolt remote — see `scripts/remote/dolt/README.md` in this repo and the beads docs.
+
+## Dependencies
+
+| Dependency | Required | Purpose |
+|------------|----------|---------|
+| [Claude Code](https://claude.com/claude-code) | Yes | The AI coding agent LETS plugs into |
+| [git](https://git-scm.com/) | Yes | Version control, branching, worktrees |
+| [beads](https://github.com/steveyegge/beads) | Yes | Task tracking (Claude Code plugin / `bd` CLI) |
+| [gh](https://cli.github.com/) | Optional | GitHub PR workflow (`LETS_PR_FLOW=github`) |
+| [jq](https://jqlang.github.io/jq/) | Optional | Statusline JSON parsing |
+
+Installing the `lets` binary itself: see **[installation.md](installation.md)**.
+
+## See also
+
+- **[installation.md](installation.md)** — installing the binary and the plugin
+- **[tasks.md](tasks.md)** — beads and the task workflow
+- **[commands.md](commands.md)** — `/lets:init`, `/lets:update`

--- a/docs/parallel-work.md
+++ b/docs/parallel-work.md
@@ -1,0 +1,48 @@
+# Parallel work
+
+Two ways to work on more than one task at a time: **`/lets:team`** spawns autonomous agents that each take a task, and **`/lets:worktree`** gives you separate directories so you can drive several sessions yourself.
+
+## `/lets:team` — autonomous agents
+
+```
+/lets:team run
+```
+
+Pick a set of tasks; the system spawns one teammate per task (the count scales with how many you select). Each teammate:
+
+1. Works in its own isolated git worktree.
+2. Creates a plan and waits for your approval — you're the lead.
+3. Implements the task once you've approved the plan.
+4. Has its commits cherry-picked back.
+
+Other subcommands: `/lets:team status` (how the teammates are doing), `/lets:team stop`.
+
+This is the right tool when you have several independent, well-scoped tasks and want them done in parallel without babysitting each one. For a single task you're actively shaping, plain `/lets:plan` + `/lets:execute` is a better fit — see **[plan-execute.md](plan-execute.md)**.
+
+## `/lets:worktree` — parallel terminals
+
+When *you* want to work on two tasks at once without constantly switching branches:
+
+```bash
+/lets:worktree create auth-feature      # in the main repo
+cd .worktrees/auth-feature && claude     # new terminal — fresh session
+/lets:start                              # pick the task, start working
+```
+
+Each worktree gets its own branch (`worktree-<name>`). The `.lets/` config, sessions, and plans are shared via a symlink, and the task database is shared via a redirect — so both terminals see the same backlog and the same config. You get the full LETS workflow in each one.
+
+When you're done with a worktree: `/lets:done` (and `/lets:end`) inside it, then `/lets:worktree remove <name>` from the main repo.
+
+A few things not to do inside a worktree:
+
+- Don't create a `feature/` branch — `worktree-<name>` *is* the working branch.
+- Don't run `/lets:worktree create` from inside a worktree.
+- Don't restructure `.lets/` or `.beads/` — they're shared with the main repo.
+
+Worktrees live in `.worktrees/` at the project root (gitignored).
+
+## See also
+
+- **[plan-execute.md](plan-execute.md)** — `/lets:team` runs this flow per task
+- **[workflow.md](workflow.md)** — where parallel work fits the overall loop
+- **[commands.md](commands.md)** — `/lets:team` and `/lets:worktree` subcommands

--- a/docs/plan-execute.md
+++ b/docs/plan-execute.md
@@ -1,0 +1,36 @@
+# Plan → Execute
+
+For anything bigger than a quick fix, LETS splits the work in two: **`/lets:plan`** works out *how* to build it, **`/lets:execute`** builds it — with you approving each step. You get a design you've reviewed before any code is written, and an implementation that doesn't surprise you.
+
+> Rule of thumb: quick fix → just do it. Medium task (a few hours) → `/lets:plan` then `/lets:execute`. Large task → `/lets:plan`, and break it into subtasks.
+
+## `/lets:plan` — design the change
+
+`/lets:plan` runs in stages:
+
+1. **Codebase exploration.** Explorer agents map the parts of the codebase the change touches — existing patterns, integration points, what's already there. The number of explorers scales with the project: a small repo gets one; a large monorepo gets up to ten, each mapping a different area.
+2. **Architecture design.** With the lay of the land in hand, the plan is designed — components, data flow, build order, trade-offs. Expert agents, selected by what the plan involves (migrations, API endpoints, Docker, …), evaluate it.
+3. **A written plan.** The result is saved to `.lets/plans/` — a step-by-step implementation plan you can read, edit, and hand to `/lets:execute`.
+
+### `--fast` — skip the agents
+
+`/lets:plan --fast` skips the explorer and architect subagent phases and plans collaboratively in the conversation instead. Use it when you already know the codebase and just want a quick talk-through and a written plan.
+
+## `/lets:execute` — build it
+
+`/lets:execute` loads the plan from `/lets:plan` and implements it in Claude Code's native plan mode. You approve each step before Claude proceeds — no step happens without your go-ahead. Use `/lets:commit` at natural commit points along the way.
+
+## The full loop
+
+```
+/lets:start ─── /lets:plan ─── (review the plan) ─── /lets:execute ─── /lets:commit ─── /lets:done ─── /lets:end
+```
+
+If you want to check a plan before executing it, `/lets:check --plan` is a fast inline pass; `/lets:review --plan` is the full multi-agent version, with agents selected from signals in the plan content.
+
+## See also
+
+- **[workflow.md](workflow.md)** — where plan → execute fits in the day-to-day loop
+- **[parallel-work.md](parallel-work.md)** — `/lets:team` runs this flow autonomously across several tasks
+- **[code-review.md](code-review.md)** — reviewing a plan with `--plan`
+- **[commands.md](commands.md)** — `/lets:plan`, `/lets:execute` flags

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -1,0 +1,77 @@
+# Tasks
+
+LETS is task-driven: every session starts by picking a task, every commit links to it. Task tracking is handled by [beads](https://github.com/steveyegge/beads) (the `bd` CLI / Claude Code plugin), which LETS depends on. The reason for a tracker rather than an ad-hoc TODO list is persistence — task descriptions, decisions, and discovery notes survive conversation compaction and carry across sessions.
+
+> beads is required. Install it with its own one-liner:
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+> ```
+> Both `lets` and `bd` need to be on `$PATH` before `/lets:init` will work end to end.
+
+## The task lifecycle
+
+```
+/lets:start  ──►  in_progress  ──►  …work, commits…  ──►  /lets:done  ──►  closed (or PR merged)
+```
+
+A task and a session aren't the same thing: a **session** is one conversation (`/lets:start` … `/lets:end`); a **task** is picked at start and finished with `/lets:done`, and may span several sessions. When you come back to an unfinished task, `/lets:start` restores its context from the task's comments.
+
+## Taking a task
+
+`/lets:start` shows the tasks that are ready to work on and asks you to pick one. Shortcuts:
+
+- `/lets:start <task-id>` — jump straight to a specific task.
+- `/lets:start --continue` — resume the task you had in progress.
+
+Picking a task sets it to `in_progress` and creates the feature branch (`feature/<task-id>-<slug>`). If you describe work without picking a task, one is created for you, so there's still a traceable record.
+
+In conversation, "take task X" / "work on X" / "switch to task X" triggers the same flow (the `take-task` skill) — it claims the task, handles any uncommitted changes, and prepares the branch.
+
+## Creating a task
+
+Say "create task" (or "new task", or "bd create …") and the `create-task` skill runs. It makes sure the required fields are present and suggests the project's existing labels:
+
+- `--title` — a summary of the issue
+- `--type` — `task` / `bug` / `feature`
+- `--priority` — `0`–`4` (0 = critical, 2 = medium, 4 = backlog)
+- `--description` — why the issue exists and what needs doing
+- `--labels` — optional grouping (the skill discovers what the project already uses)
+
+Tasks get short hash-based IDs, collision-free even with several people on a shared database.
+
+A few beads conventions LETS follows:
+
+- **Update tasks with comments, not by overwriting.** `bd update --notes` / `--description` overwrite existing content; `bd comments add` appends. Incremental progress goes in comments.
+- **Group with labels, not epics with child IDs** — avoids ID collisions in a multi-user setup.
+- **Add dependencies sparingly** — only when task B literally cannot start until task A is done. Most tasks are independent.
+
+## Notes — recording what you learn
+
+`/lets:note` adds a note to the active task: a decision, a gotcha, an infrastructure fact, a reference. These are stored as task comments, so they survive context limits and are there the next time anyone opens the task. Claude will *suggest* `/lets:note` when something worth recording comes up — you run the command, so you stay in control of what gets written.
+
+## `/lets:status` — where things stand
+
+`/lets:status` gives a compact overview: what's ready, what's in progress, what's blocked, recent activity. It's also what `/lets:start` runs to show you the task list.
+
+## `/lets:brainstorm` — working the backlog
+
+`/lets:brainstorm` is interactive ideation, in four modes:
+
+- **Review backlog** — agents go through your task list, find patterns, suggest priorities.
+- **Explore ideas** — a deep dive into a specific area, with codebase analysis.
+- **Quick brainstorm** — fast ideation on a topic.
+- **Cleanup** — find stale tasks, broken dependencies, forgotten work.
+
+## Memory — knowledge that outlives a session
+
+beads has a memory feature for insights you want to keep across sessions and conversations: `bd remember "…"` stores one, `bd memories <keyword>` searches them, `bd forget <key>` removes one. Use it for things like "X doesn't work because Y", deployment quirks, or config facts you'll need again — knowledge that isn't tied to one task and shouldn't live in a scratch file.
+
+## Shared backlogs for teams
+
+For more than one developer, beads can point at a shared database via a [Dolt](https://github.com/dolthub/dolt) remote — everyone connects to the same backlog, sees the same task states, and the history is versioned. Setup is on the beads side; see its docs, and `scripts/remote/dolt/README.md` in this repo for the remote deployment.
+
+## See also
+
+- **[workflow.md](workflow.md)** — the session/task loop
+- **[configuration.md](configuration.md)** — `lets init` vs `bd init` setup order
+- **[commands.md](commands.md)** — `/lets:start`, `/lets:status`, `/lets:note`, `/lets:brainstorm`

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,88 @@
+# Workflow
+
+LETS gives Claude Code a structure to work inside: every session starts with a task, every commit links to it, and context survives across sessions and conversation compaction. This page walks through the day-to-day loop.
+
+## The session loop
+
+```
+/lets:start ─── choose how to work ─── /lets:commit ─── /lets:done ─── /lets:end
+```
+
+**`/lets:start`** — restores context from your last session (what you did, what's next), shows the tasks you can pick up, and creates a feature branch for the one you choose. You always work on a task; if you don't pick one, you'll be asked to. Branches are named `feature/<task-id>-<slug>`.
+
+**Choose how to work** — see [the three ways to work](#three-ways-to-work) below.
+
+**`/lets:commit`** — reviews your changes and creates a conventional commit (`feat:`, `fix:`, `docs:`, …) with the task ID in the scope and a `Task:` footer. Use this instead of `git commit` directly — it keeps the format consistent and links the commit to the task.
+
+**`/lets:done`** — finishes the task. In GitHub mode it pushes the branch and opens a PR (the task stays open until the PR merges). In local/bitbucket mode it merges to your merge branch and closes the task.
+
+**`/lets:end`** — saves a session summary so the next conversation picks up where you left off.
+
+> Two separate lifecycles: a **session** is one conversation (`/lets:start` … `/lets:end`); a **task** is picked at start and finished with `/lets:done` — it can span several sessions. When you return to an unfinished task, `/lets:start` restores its context from the task's comments.
+
+## Three ways to work
+
+Once you've started a session, pick the approach that fits the task.
+
+### You write the code
+
+Write code with Claude in the conversation. Helpers along the way:
+
+| Command | What it does |
+|---------|--------------|
+| `/lets:opinion` | Technical decision analyzed by expert agents in parallel, with a recommendation |
+| `/lets:ask` | Quick question to a single expert agent |
+| `/lets:check` | Quick sanity check before a commit — 6 perspectives, inline, ~30s |
+| `/lets:review` | Full multi-agent code review (~2-3 min) |
+
+### You plan, Claude builds
+
+For anything non-trivial — design first, then implement:
+
+| Command | What it does |
+|---------|--------------|
+| `/lets:brainstorm` | Ideation — review the backlog, explore an idea, quick brainstorm, cleanup |
+| `/lets:plan` | Design how to build it — codebase exploration, architecture, a written plan |
+| `/lets:execute` | Claude implements the plan, with your approval at each step |
+
+See **[plan-execute.md](plan-execute.md)** for the full flow.
+
+### Agents work in parallel
+
+| Command | What it does |
+|---------|--------------|
+| `/lets:team` | Spawn autonomous agents that implement several tasks at once, each in its own worktree |
+| `/lets:worktree` | Open parallel sessions in separate terminals — you drive each one |
+
+See **[parallel-work.md](parallel-work.md)**.
+
+## How LETS keeps Claude on track
+
+**SessionStart + PreCompact hooks.** On every Claude Code conversation, `lets hook session-start` (and `lets hook precompact`) runs and emits a small `## LETS Config` block — plus a notice if your rules file is out of date. The workflow rules themselves live in `<project>/.claude/rules/lets-rules.md` (copied there by `/lets:init`, re-synced by `/lets:update` when a new release ships), which Claude Code loads as project instructions. SessionStart fires on new, resumed, cleared, and compacted sessions; PreCompact makes sure the rules survive when a long session gets compacted. This is what makes Claude follow the workflow without you having to remind it.
+
+**LETS boxes.** After key actions, Claude shows a small box with the most likely next steps, so you always know what to do next:
+
+```
+┌─ LETS ─────────────────────────┐
+│  Review?  /lets:review         │
+│  Commit?  /lets:commit         │
+└────────────────────────────────┘
+```
+
+## When to use which review
+
+| Change | Path |
+|--------|------|
+| Small | `/lets:check` → `/lets:commit` |
+| Significant | `/lets:check` → `/lets:review --local` → fix → `/lets:commit` → PR |
+| PR already exists | `/lets:review <PR>`, or the full `/lets:github-pr <PR>` lifecycle |
+| Quick plan check | `/lets:check --plan` |
+
+More in **[code-review.md](code-review.md)**.
+
+## See also
+
+- **[commands.md](commands.md)** — every `/lets:*` command in one place
+- **[tasks.md](tasks.md)** — how task tracking works
+- **[plan-execute.md](plan-execute.md)** — the plan → execute flow
+- **[configuration.md](configuration.md)** — settings and file layout


### PR DESCRIPTION
## Summary

First batch under **Post-repo-public fixes** (`lets-81q1o`):

- **CI workflow** (`97ba27d`, `c44fa1b`) — `.github/workflows/ci.yml` runs `make build` / `make vet` / `make test` / `golangci-lint` on PRs to `main` and pushes to `main`; `cli/.golangci.yml` migrated to golangci-lint v2; 16 pre-existing errcheck/staticcheck findings fixed (all mechanical, behavior unchanged).
- **Docs restructure** (`ed4d581`) — `README.md` reorganized as a landing-page tour (Why LETS → Quick Start → Commands → Expert Agents → Using LETS → reference tail); the exhaustive reference moved into a new `docs/` tree: `workflow.md`, `plan-execute.md`, `code-review.md`, `agents.md`, `parallel-work.md`, `tasks.md`, `commands.md`, `configuration.md` + an index. Each README section links to its deep-dive page. `.gitignore`: anchored `AGENTS.md` → `/AGENTS.md` so `docs/agents.md` isn't swept up by it on case-insensitive filesystems.

## Notes

- `lets-81q1o` is a living umbrella task — it stays open after this merges; more post-public items will land as they come up.
- Once `CI` has run on this PR, add it as a required status check in the `main protection` ruleset alongside `Verify version coherence`.

Task: lets-81q1o

🤖 Generated with [Claude Code](https://claude.com/claude-code)