### PR TITLE
chore: release v0.5.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lets",
       "source": "./plugins/lets",
       "description": "Development workflow with session management, code review, and task tracking",
-      "version": "0.5.2"
+      "version": "0.5.3"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,16 @@
 ## [Unreleased]
 
 ### Added
-- Community health files: `SECURITY.md` (private vulnerability reporting via the Security tab), `CONTRIBUTING.md`, GitHub issue/PR templates, and `.github/dependabot.yml` (gomod + github-actions).
+- Community health files: `SECURITY.md` (private vulnerability reporting via the Security tab), `CONTRIBUTING.md`, GitHub issue/PR templates, `.github/dependabot.yml` (gomod + github-actions), and `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1; conduct reports via a private GitHub security advisory).
+- CI: `.github/workflows/ci.yml` runs `make build` / `make vet` / `make test` / `golangci-lint` on every PR to `main` and every push to `main`, added as required status checks alongside `Verify version coherence`. (`verify-versions.yml` only checks source-tree version coherence — it doesn't compile, test, or lint the code.)
+- `docs/` manual — `workflow.md`, `plan-execute.md`, `code-review.md`, `agents.md`, `parallel-work.md`, `tasks.md`, `commands.md`, `configuration.md`, plus an index. The exhaustive reference now lives here; the README links to each page.
 
 ### Changed
+- README restructured as a landing-page tour (Why LETS? → Quick Start → Commands → Expert Agents → Using LETS → reference tail). The full reference moved to `docs/`; each section points to its deep-dive page; refreshed screenshot; pruned unused images.
 - Repository made public — removed the "repo is private during testing" notices from `README.md` and `docs/installation.md`; the `docs/installation.md` manual-download example no longer hardcodes a version number.
-- Doc/reality drift fixes: `CLAUDE.md` `docs/` description now matches the actual tree (`installation.md` + images); `RELEASING.md` recovery steps account for release immutability + the `Protect release tags` ruleset, and dropped the stale "install.sh script (future)" line that already shipped.
+- `cli/.golangci.yml` migrated to golangci-lint v2; 16 pre-existing `errcheck`/`staticcheck` findings fixed (mechanical, no behavior change). Bumped `golang.org/x/mod` to 0.36.0 (Dependabot).
+- `.gitignore`: anchored the `AGENTS.md` pattern to `/AGENTS.md` so it no longer also ignores `docs/agents.md` on case-insensitive filesystems.
+- Doc/reality drift fixes: `CLAUDE.md` `docs/` description now matches the actual tree (`installation.md` + images, plus `.github/workflows/`); `RELEASING.md` recovery steps account for release immutability + the `Protect release tags` ruleset, and dropped the stale "install.sh script (future)" line that already shipped.
 
 ## [0.5.2] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.3] - 2026-05-13
+
 ### Added
 - Community health files: `SECURITY.md` (private vulnerability reporting via the Security tab), `CONTRIBUTING.md`, GitHub issue/PR templates, `.github/dependabot.yml` (gomod + github-actions), and `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1; conduct reports via a private GitHub security advisory).
 - CI: `.github/workflows/ci.yml` runs `make build` / `make vet` / `make test` / `golangci-lint` on every PR to `main` and every push to `main`, added as required status checks alongside `Verify version coherence`. (`verify-versions.yml` only checks source-tree version coherence — it doesn't compile, test, or lint the code.)
@@ -360,7 +362,8 @@ Initial release with expert agents team.
 - SessionStart hook injecting workflow rules
 - Plugin structure: commands, agents, hooks
 
-[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.2...HEAD
+[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.3...HEAD
+[0.5.3]: https://github.com/restarter/lets-workflow/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/restarter/lets-workflow/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/restarter/lets-workflow/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/restarter/lets-workflow/compare/v0.3.0...v0.5.0

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ In Claude Code:
 /plugin install lets
 ```
 
-> **For teams:** when Claude Code asks who to install for, pick **"Install for all collaborators on this repository" (project scope)** — the choice goes into `.claude/settings.json`, so teammates inherit `lets` without re-installing.
+> **Install scope:** when Claude Code asks who to install for, pick **"Install for all collaborators on this repository" (project scope)** — the choice goes into `.claude/settings.json`, so teammates inherit `lets` without re-installing. **Local** scope (just this checkout) is fine for a solo or throwaway project. Avoid **user** scope: at user scope the SessionStart/PreCompact hooks fire in *every* project you open, including ones that never ran `/lets:init` — smoother user-scope handling is planned for a future update.
 
 (From a local clone instead: `git clone …` then `/plugin marketplace add ./lets-workflow` and `/plugin install lets`.)
 

--- a/plugins/lets/.claude-plugin/plugin.json
+++ b/plugins/lets/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "author": {
     "name": "restarter",
     "url": "https://github.com/restarter"

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.5.2
+version: 0.5.3
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->


### PR DESCRIPTION
## Release v0.5.3

Patch release — docs/infra/community changes since v0.5.2, no plugin behavior changes.

**Changelog:** see `[0.5.3]` in [CHANGELOG.md](CHANGELOG.md). Highlights:
- `docs/` manual + README restructured as a landing-page tour (each section links to its deep-dive page); refreshed screenshot.
- CI workflow (`ci.yml`: build / vet / test / golangci-lint on PRs + pushes to `main`), added as required status checks.
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1); the rest of the community-health files; repo made public.
- golangci-lint v2 migration + `golang.org/x/mod` 0.36.0 bump; `.gitignore` `AGENTS.md` → `/AGENTS.md` fix.

Commits: CHANGELOG backfill for the un-logged `lets-81q1o` entries, then the `make bump` commit (version bumps in `plugin.json` / `marketplace.json` / `lets-rules.md` frontmatter + `[Unreleased]` → `[0.5.3]` promotion). `verify-versions.yml` + the `CI` jobs run on this PR.

After merge: `make release-tag VERSION=0.5.3` tags the merge commit and triggers `release.yml` (goreleaser → GH Release).

Task: lets-81q1o

🤖 Generated with [Claude Code](https://claude.com/claude-code)