### PR TITLE
docs: align the README how-to-work box (lets-4fmgu)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ A LETS session runs a loop: start, work, commit, finish.
 ```
 ┌─ You write code yourself ─────────────────────────────────────────────────┐
 │  Write code with Claude. Use helpers along the way:                       │
-│  /lets:opinion   Technical decision with expert agents                     │
+│  /lets:opinion   Technical decision with expert agents                    │
 │  /lets:ask       Quick question to a single expert                        │
 │  /lets:check     Quick sanity check (6 perspectives, ~30s)                │
 │  /lets:review    Full multi-agent code review (~2-3 min)                  │


### PR DESCRIPTION
The `/lets:opinion` row in the "choose how to work" ASCII box (`## 🔧 Using LETS`) was one column too wide, so its right `│` stuck out past the rest. Trimmed one padding space — all rows are 77 columns now.

Follow-up nit on top of #78. Task: lets-4fmgu (living bucket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)