### PR TITLE
chore: release v0.5.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lets",
       "source": "./plugins/lets",
       "description": "Development workflow with session management, code review, and task tracking",
-      "version": "0.5.3"
+      "version": "0.5.4"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.4] - 2026-05-13
+
 ### Fixed
 - `/lets:update`'s binary-upgrade hint no longer points at a 404 — dropped `brew upgrade lets` (no Homebrew tap yet) and corrected the install URL to `https://raw.githubusercontent.com/restarter/lets-workflow/main/scripts/install.sh` (it was missing `scripts/`). Note: the broken hint is baked into the v0.5.2 / v0.5.3 `lets` binaries; this fix takes effect once you're on a newer binary. (lets-4fmgu)
 - A rules-drift `## LETS Notice` from the SessionStart hook now reliably reaches the user even mid-slash-command: the hook appends a "surface this to the user" instruction to the block, and `/lets:start` was taught to put the notice first in its output (`start.md` previously said nothing about it, so the orchestrator relied only on the small `## LETS Notice` rule in `lets-rules.md` and tended to forget). (lets-4fmgu)
@@ -371,7 +373,8 @@ Initial release with expert agents team.
 - SessionStart hook injecting workflow rules
 - Plugin structure: commands, agents, hooks
 
-[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.3...HEAD
+[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.4...HEAD
+[0.5.4]: https://github.com/restarter/lets-workflow/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/restarter/lets-workflow/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/restarter/lets-workflow/compare/v0.5.1...v0.5.2
 [0.5.1]: https://github.com/restarter/lets-workflow/compare/v0.5.0...v0.5.1

--- a/plugins/lets/.claude-plugin/plugin.json
+++ b/plugins/lets/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "author": {
     "name": "restarter",
     "url": "https://github.com/restarter"

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.5.3
+version: 0.5.4
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->


### PR DESCRIPTION
## Release v0.5.4

Patch release — the `lets-4fmgu` post-0.5.3 fixes (all merged via #78 / #79), now bumped + promoted to `[0.5.4]`.

**Changelog:** see `[0.5.4]` in [CHANGELOG.md](CHANGELOG.md). Highlights:
- Fixed: `/lets:update`'s binary-upgrade hint no longer 404s (dropped `brew upgrade lets`, corrected the install URL); rules-drift `## LETS Notice` reliably surfaces even mid-slash-command; the "lets binary not found" hint points at the curl one-liner.
- Changed: `/lets:update` plugin-update guidance → `/plugin marketplace update lets-workflow` + `/reload-plugins` (dropped `claude plugin update --scope`); auto-update tip in `/lets:init` / README / `docs/installation.md`; doc freshen across README / installation.md / cli/README.md / install-deprecated.md.

This PR is just the version bump (`plugin.json` / `marketplace.json` / `lets-rules.md` frontmatter → 0.5.4 + `[Unreleased]` → `[0.5.4]` promotion). `verify-versions.yml` + the CI jobs run on it.

After merge: `make release-tag VERSION=0.5.4` tags the merge commit and triggers `release.yml` (goreleaser → GH Release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)