### PR TITLE
chore: release v0.5.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lets",
       "source": "./plugins/lets",
       "description": "Development workflow with session management, code review, and task tracking",
-      "version": "0.5.4"
+      "version": "0.5.5"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.5.5] - 2026-05-27
+
 ### Added
 - **`/lets:check --branch` and `/lets:review --branch` (lets-id3d6).** Full-branch review against `$LETS_MERGE_BRANCH` using a three-dot diff (`git diff main...HEAD` — same shape GitHub renders for a PR), so you can do a PR-equivalent review locally before pushing without needing a draft PR. Guards: refuses on the merge branch itself, refuses if `$LETS_MERGE_BRANCH` is unset/empty (mirrors `/lets:done`'s pattern), refuses if the merge ref is missing locally (with a `git fetch origin MB:MB` hint that creates the local branch, not just the remote ref), refuses if zero commits ahead. JSON `mode` values: `check-branch` (preserves check.md's `check-*` prefix) and `branch-review` (preserves review.md's `{kind}-review` naming consistent with `local-review` / `plan-review`). Branch reviews save to a dedicated artifact `.lets/reviews/{date}-branch-review.md` (PR-equivalent diff deserves its own file). Workflow Option A in `review.md` documents `--branch` as an optional final pass for multi-commit branches before pushing.
 - New `## AskUserQuestion Conventions` section in `lets-rules.md` codifies 8 rules for `AskUserQuestion` calls: header chip style (4-12 chars descriptive, `"LETS"` forbidden), question wording, label/description format, `multiSelect` use, `preview` constraints, follow-through (invoke via Skill tool), and skip-when-one-action. Includes a worked example. CLAUDE.md "When Adding/Modifying" table and "Command Checklist" point at it. (lets-uffs7)
@@ -408,7 +410,8 @@ Initial release with expert agents team.
 - SessionStart hook injecting workflow rules
 - Plugin structure: commands, agents, hooks
 
-[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.4...HEAD
+[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.5...HEAD
+[0.5.5]: https://github.com/restarter/lets-workflow/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/restarter/lets-workflow/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/restarter/lets-workflow/compare/v0.5.2...v0.5.3
 [0.5.2]: https://github.com/restarter/lets-workflow/compare/v0.5.1...v0.5.2

--- a/plugins/lets/.claude-plugin/plugin.json
+++ b/plugins/lets/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "author": {
     "name": "restarter",
     "url": "https://github.com/restarter"

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.5.4
+version: 0.5.5
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->


### PR DESCRIPTION
## Summary

Release v0.5.5. Bundles 25 CHANGELOG entries accumulated since v0.5.4 (2026-05-13).

**Source-tree bumps:**
- `plugins/lets/.claude-plugin/plugin.json`: 0.5.4 → 0.5.5
- `.claude-plugin/marketplace.json`: 0.5.4 → 0.5.5
- `plugins/lets/rules/lets-rules.md` frontmatter: 0.5.4 → 0.5.5
- `CHANGELOG.md`: `[Unreleased]` rolled forward to `[0.5.5] - 2026-05-27`

Full notes: [CHANGELOG.md §[0.5.5]](https://github.com/restarter/lets-workflow/blob/feature/lets-5b3k9-release-v0.5.5/CHANGELOG.md#055---2026-05-27).

**Highlights**
- `/lets:check --branch` and `/lets:review --branch` for PR-equivalent local review (lets-id3d6)
- `lets worktree` Go subcommand with JSON envelope + local dev workflow `make dev` / `make dev-tmux` (lets-rqep4)
- Trunk-mode option in `take-task` skill (lets-3o9d7)
- `{LETS_FOO}` substitution disambiguation in AskUserQuestion (lets-7jise)
- AskUserQuestion Conventions + Skill tool migration (lets-uffs7 + lets-5pkvh)
- English-only enforcement for written artifacts (lets-dmsnw)
- `/lets:done` survives already-merged branch + no-hard-wrap rule (lets-mzeys)

## Test plan
- [x] `make test` (with `-race`) — green
- [x] `make build` — green
- [x] `make verify-versions` — green
- [ ] CI: `Verify version coherence` + `Build, vet & test` + `Lint (golangci-lint)`
- [ ] After merge: `make release-tag VERSION=0.5.5` triggers goreleaser → 5 archives + checksums on GH Releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)