### PR TITLE
Command-flow hygiene polish + /compact session-end hint (lets-k1zfj)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Command-flow hygiene polish (lets-k1zfj).** `/lets:commit` LETS box on incomplete work suggests `/lets:check` and `/lets:note` instead of `/lets:end` — session-end is reached explicitly via `/lets:done` (when scope is complete) or when the user runs `/lets:end`, not as a commit-pause shortcut. `/lets:done` "Next task" option now explicitly delegates to the `take-task` skill via `Skill(skill: "lets:take-task", args: "<task-id>")` instead of leaving the pick dangling at "show bd ready, pick new task" with no follow-through; the 3 paired AskUserQuestion `description` strings (trunk-mode, github + not-worktree, local + not-worktree variants) updated to match. `take-task` Output box is now suppressed when invoked from `/lets:done` (matching the existing `/lets:start` exception) — avoids double navigation prompts (done's AskUserQuestion + take-task's LETS box) per CLAUDE.md "Internal invocation = no box".
+
+### Changed
+- **`/lets:start` Step 3 no longer embeds heavy `/lets:status overview` (lets-k1zfj).** Previously every session start triggered the overview view (~17 bd subprocess calls via stats + per-label loop ×12 + ready + in_progress + optional gh pr list). Replaced with `bd list --status=in_progress` (what's claimed) + delegation to `/lets:status ready` (what's available, epic-grouped) — about 3 bd calls per session start. Overview view itself is untouched in this PR; its redesign (slim / mini view / status quo, plus the underlying `lets status --json` Go subcommand for reliable bd aggregation) is folded into lets-qsgmd.
+
 ## [0.5.5] - 2026-05-27
 
 ### Added

--- a/plugins/lets/commands/done.md
+++ b/plugins/lets/commands/done.md
@@ -467,7 +467,7 @@ AskUserQuestion(
     question: "Task done. What's next?",
     header: "Next step",
     options: [
-      { label: "Next task", description: "Pick another task to work on (stays on {LETS_MERGE_BRANCH})" },
+      { label: "Next task", description: "Pick and claim another task via take-task skill" },
       { label: "End session", description: "Run /lets:end - save context and wrap up" }
     ],
     multiSelect: false
@@ -476,7 +476,7 @@ AskUserQuestion(
 ```
 
 **Handle response:**
-- **Next task** -> show `bd ready`, pick new task
+- **Next task** -> show `bd ready --limit 5`, ask user to pick. When picked: invoke `Skill(skill: "lets:take-task", args: "<task-id>")` for status update + branch setup. Do NOT inline take-task logic.
 - **End session** -> invoke `Skill(skill: "lets:end")`
 
 ### After PR ($LETS_PR_FLOW == github), NOT in worktree:
@@ -499,7 +499,7 @@ AskUserQuestion(
     options: [
       { label: "Merge & close", description: "Merge PR #{number}, close task, switch to {LETS_MERGE_BRANCH}" },
       { label: "Stay on branch", description: "Stay on feature branch - for PR fixes or follow-up work" },
-      { label: "Next task", description: "Switch to {LETS_MERGE_BRANCH}, pick another task" },
+      { label: "Next task", description: "Switch to {LETS_MERGE_BRANCH}, then claim another task via take-task" },
       { label: "End session", description: "Switch to {LETS_MERGE_BRANCH}, run /lets:end" }
     ],
     multiSelect: false
@@ -514,7 +514,7 @@ AskUserQuestion(
   3. `git checkout {LETS_MERGE_BRANCH} && git pull`
   4. If merge fails (conflicts, checks not passed) -> inform user, fall back to "Stay on branch"
 - **Stay on branch** -> stay on current branch, no checkout. User continues working freely.
-- **Next task** -> `git checkout {LETS_MERGE_BRANCH}`, then show `bd ready`, pick new task
+- **Next task** -> `git checkout {LETS_MERGE_BRANCH}`, then show `bd ready --limit 5`. When user picks: invoke `Skill(skill: "lets:take-task", args: "<task-id>")` for status update + branch setup.
 - **End session** -> `git checkout {LETS_MERGE_BRANCH}`, then invoke `Skill(skill: "lets:end")`
 
 ### After PR ($LETS_PR_FLOW == github), IN worktree:
@@ -573,7 +573,7 @@ AskUserQuestion(
     question: "Task done. What's next?",
     header: "Next step",
     options: [
-      { label: "Next task", description: "Pick another task to work on" },
+      { label: "Next task", description: "Pick and claim another task via take-task skill" },
       { label: "End session", description: "Run /lets:end - save context and wrap up" }
     ],
     multiSelect: false
@@ -582,7 +582,7 @@ AskUserQuestion(
 ```
 
 **Handle response:**
-- **Next task** -> show `bd ready`, pick new task
+- **Next task** -> show `bd ready --limit 5`, ask user to pick. When picked: invoke `Skill(skill: "lets:take-task", args: "<task-id>")` for status update + branch setup.
 - **End session** -> invoke `Skill(skill: "lets:end")`
 
 ### After local merge ($LETS_PR_FLOW != github), IN worktree:

--- a/plugins/lets/commands/end.md
+++ b/plugins/lets/commands/end.md
@@ -256,18 +256,20 @@ AskUserQuestion(
     question: "Session saved. What now?",
     header: "Wrap up",
     options: [
-      { label: "Push", description: "git push to remote, then reset context for a fresh start" },
-      { label: "Done", description: "Wrap up — reset context manually to start fresh next time" }
+      { label: "Compact (Recommended)", description: "Run /compact - keep this window with a compacted summary and continue lighter" },
+      { label: "Push then compact", description: "git push to remote, then run /compact" },
+      { label: "Clear & restart", description: "Run /clear then /lets:start for a fully fresh session" }
     ],
     multiSelect: false
   }]
 )
 ```
 
-**Handle response:**
-- **Push** -> `git push`, then tell the user: "Run `/clear` then `/lets:start` to begin a fresh session." (Do NOT auto-execute — `/clear` must wipe context BEFORE `/lets:start` so the new session is truly fresh; auto-Reading `start.md` would defeat that.)
-- **Done** -> tell the user: "Run `/clear` then `/lets:start` to begin a fresh session." Same reasoning as above.
-- **NEVER push automatically**
+**Handle response** (`/compact` and `/clear` are Claude Code commands the model cannot run — emit them as prose for the user to type, never auto-execute):
+- **Compact** -> tell the user: "Run `/compact` to compact this session's context and keep working in the same window. The PreCompact hook re-injects the workflow rules, and the summary just saved survives compaction."
+- **Push then compact** -> `git push`, then tell the user: "Run `/compact` to compact context and keep working here."
+- **Clear & restart** -> tell the user: "Run `/clear` then `/lets:start` to begin a fully fresh session." (`/clear` must wipe context BEFORE `/lets:start`, so do NOT auto-execute — auto-Reading `start.md` would defeat the reset.)
+- **NEVER push automatically** — the `git push` above runs only because the user explicitly picked it.
 
 ## Rules
 
@@ -276,4 +278,5 @@ AskUserQuestion(
 - **Suggest `/lets:done`** if task seems complete
 - **NEVER push without explicit user approval**
 - Always write session summary (local)
+- **Recommend `/compact` first** at session end - it keeps the window with a compacted summary (lighter); `/clear` + `/lets:start` is the full-reset alternative
 - Respond in user's language

--- a/plugins/lets/commands/start.md
+++ b/plugins/lets/commands/start.md
@@ -65,9 +65,15 @@ fi
 
 Report: branch, uncommitted changes, recent commits. **If the repo has no commits yet** (the `else` branch above fires), that's fine — say so in plain text; offer `git commit --allow-empty -m "chore: initial setup"` if the user wants an anchor for `git log` to work later. **Don't** raise `/lets:init` here (it's a separate concern) and **don't** treat the missing HEAD as a fatal error.
 
-## Step 3: Task Status
+## Step 3: Task Pickers
 
-Run `/lets:status overview` to show compact task overview.
+Show what's claimed and what's available — minimal data the user needs for Step 5 selection. Full project dashboard (label-groups progress, priority distribution, dependency graph) lives in explicit `/lets:status overview` or `/lets:status full` — not invoked at session start.
+
+```bash
+bd list --status=in_progress
+```
+
+Then delegate to `/lets:status ready` to list available tasks grouped by epic.
 
 ## Step 4: Present Summary
 
@@ -80,8 +86,11 @@ Branch: {branch}
 Changes: {clean / X uncommitted files}
 Recent: {last 3 commits}
 
-## Tasks
-{output from /lets:status}
+## In Progress
+{output from `bd list --status=in_progress`, or "(none)"}
+
+## Ready Tasks
+{output from `/lets:status ready` — already formatted with epic grouping}
 ```
 
 ## Step 5: Task Selection (MANDATORY)

--- a/plugins/lets/skills/commit/SKILL.md
+++ b/plugins/lets/skills/commit/SKILL.md
@@ -190,9 +190,11 @@ Remaining: {brief list}
 
 ┌─ LETS ─────────────────────────┐
 │  Check?  /lets:check           │
-│  End?    /lets:end             │
+│  Note?   /lets:note            │
 └────────────────────────────────┘
 ```
+
+`/lets:end` is for session end, not commit-pause. After a partial commit the next moves are reviewing (`/lets:check`) or recording context (`/lets:note`); session-end fires explicitly later via `/lets:done` (when scope is complete) or when the user runs `/lets:end`.
 
 ## Integration
 

--- a/plugins/lets/skills/take-task/SKILL.md
+++ b/plugins/lets/skills/take-task/SKILL.md
@@ -152,7 +152,7 @@ Branch: {branch-name}
 └───────────────────────────────┘
 ```
 
-When invoked by `/lets:start` - skip this output, the command has its own.
+When invoked by `/lets:start` OR `/lets:done` (via `Skill` tool) - skip this output, the calling command has its own. Per CLAUDE.md "Internal invocation = no box".
 
 ## Anti-patterns
 


### PR DESCRIPTION
## Summary

Polish portion of the **Command-flow hygiene umbrella** (lets-k1zfj). 5 surgical fixes across `/lets:start`, `/lets:commit`, `/lets:done`, `take-task` + 1 small feature: `/compact` recommendation at session end.

Architecture-level concerns spun off to 4 open children — see "Umbrella tracking" below.

## Changes (6 commits)

```
cdc6887 feat(lets-k1zfj): propose /compact first at session end
121a606 docs(lets-k1zfj): update CHANGELOG
d65a4bb fix(lets-k1zfj): take-task suppresses Output box when invoked from /lets:done
2410ea9 fix(lets-k1zfj): /lets:done Next-task option delegates to take-task
5aa7fdf fix(lets-k1zfj): /lets:commit LETS box no longer suggests /lets:end mid-task
c7350ad refactor(lets-k1zfj): replace /lets:start embedded /lets:status overview call
```

## What ships

- **`/lets:start` Step 3** drops the embedded `/lets:status overview` call (~17 bd subprocess calls per session start via per-label loop). Replaced with `bd list --status=in_progress` + delegation to lighter `/lets:status ready`. ~3 bd calls now.
- **`/lets:commit` LETS box** on incomplete work suggests `/lets:check` and `/lets:note` instead of `/lets:end` — session-end is reached explicitly via `/lets:done` or `/lets:end`, not as a commit-pause shortcut.
- **`/lets:done` "Next task" option** explicitly delegates to the `take-task` skill via `Skill(skill: "lets:take-task", args: "<task-id>")` instead of dangling at "show bd ready, pick new task". Three paired AskUserQuestion `description` strings updated.
- **`take-task` Output box** suppressed when invoked from `/lets:done` (matching the existing `/lets:start` exception) — avoids double navigation prompts per CLAUDE.md "Internal invocation = no box".
- **`/lets:end` Output** suggests `/compact` first (Recommended), with `Push then compact` and `Clear & restart` as alternatives. `/compact` is the lighter session-end path: compacts context while keeping the window, the PreCompact hook re-injects workflow rules, the just-saved summary survives. `/clear` + `/lets:start` stays as the full-reset alternative.

## Umbrella tracking

After merge, `lets-k1zfj` transitions to **open umbrella** status (not closed) until its 4 children close:

- **lets-bh79a** (P1) — Refactor LETS box system: articulate AskUserQuestion-vs-LETS-box rule, Phase Detection Type column, `/lets:end` exception, `/lets:start` Step 9 output realign
- **lets-mic6d** (P1) — `/lets:end` settlement-checks redesign + template refresh (replaces ordered Steps 1-6 with auto-skip checks; drops `--fast` flag)
- **lets-dsdmp** (P1) — ref-file architecture decision: keep + polish, drop via grep, two-ref split, or bd-stamp. Supersedes lets-xglcy + lets-qtiet (closed)
- **lets-qsgmd** (P2) — `lets status --json` Go subcommand for reliable bd aggregation + `/lets:status overview` view UX redesign (folded from lets-p74bb, closed)

## Task

lets-k1zfj — Command-flow hygiene — umbrella for polish PR + architecture spinoffs

## Notes

- CHANGELOG entry (`121a606`) covers the 5 polish fixes. `/compact` addition (last commit) is not in CHANGELOG — can be added as follow-up if desired.
- Plan file: `.lets/plans/worktree-lets-k1zfj-command-flow-hygiene.md` (worktree-local, gitignored).