### PR TITLE
fix(lets-ijpw4): escape control bytes in TestStripControl (unbreak main Lint CI)

### DIFF
--- a/cli/internal/statusline/spawn_guard_test.go
+++ b/cli/internal/statusline/spawn_guard_test.go
@@ -1,0 +1,17 @@
+package statusline
+
+import "testing"
+
+// TestBackgroundSpawnsDisabledUnderTest pins the contract that the detached
+// self-exec usage/task refreshers are suppressed while running under `go test`.
+//
+// If this regresses, the render tests re-exec the test binary (os.Executable()),
+// which re-runs the whole suite and spawns more detached copies — an exponential
+// fork bomb that hangs `go test -race ./...` on Linux CI (SIGTERM / exit 143).
+// Assert the guard signal directly so a regression fails cleanly here instead.
+func TestBackgroundSpawnsDisabledUnderTest(t *testing.T) {
+	if !backgroundSpawnsDisabled() {
+		t.Fatal("background self-exec spawns must be disabled under `go test` " +
+			"(else statusline render tests fork-bomb the test binary — see lets-ijpw4)")
+	}
+}

--- a/cli/internal/statusline/statusline.go
+++ b/cli/internal/statusline/statusline.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/restarter/lets-workflow/cli/internal/gitutil"
@@ -273,6 +274,20 @@ func detectBranch(dir string) string {
 	return ""
 }
 
+// backgroundSpawnsDisabled reports whether the detached self-exec refreshers
+// (spawnBackgroundFetch / spawnBackgroundTaskFetch) must be suppressed.
+//
+// Under `go test`, os.Executable() is the test binary, not the real `lets` CLI.
+// Re-exec'ing it with "statusline --fetch-…" makes Go's flag parser stop at the
+// "statusline" positional and run the whole test suite; every render test then
+// spawns a detached copy of the suite, which spawns more — an exponential fork
+// bomb. On Linux CI that exhausts the process table and the job dies with
+// SIGTERM (`go test -race ./...` → exit 143); on macOS `go test` reports PASS
+// and exits before the explosion is visible, silently leaking processes. The
+// production binary reports false and spawns normally; the real fetch path is
+// covered by integration tests that invoke the built binary.
+func backgroundSpawnsDisabled() bool { return testing.Testing() }
+
 // spawnBackgroundFetch starts a detached subprocess that fetches the usage
 // API and writes to cacheDir/usage. Mirrors bash:
 //
@@ -282,6 +297,9 @@ func detectBranch(dir string) string {
 // group (so the child survives the parent shell's SIGHUP on exit).
 // detachProcessGroup is build-tag split: spawn_unix.go vs spawn_windows.go.
 func spawnBackgroundFetch(cacheDir string) {
+	if backgroundSpawnsDisabled() {
+		return
+	}
 	exe, err := os.Executable()
 	if err != nil {
 		return
@@ -302,6 +320,9 @@ func spawnBackgroundFetch(cacheDir string) {
 // resolved from the inherited PATH — if it's absent the child fails silently
 // and Line 2 degrades to id-only, which is the documented graceful path.
 func spawnBackgroundTaskFetch(cacheDir, taskID string) {
+	if backgroundSpawnsDisabled() { // see backgroundSpawnsDisabled: no self-exec under `go test`
+		return
+	}
 	exe, err := os.Executable()
 	if err != nil {
 		return

--- a/cli/internal/statusline/taskfetch_test.go
+++ b/cli/internal/statusline/taskfetch_test.go
@@ -192,7 +192,7 @@ func TestFetchAndCacheTaskStatus_RejectsBadID(t *testing.T) {
 // DEL and C1 control bytes while keeping printable text (incl. the now-inert
 // "[2J" that loses its ESC introducer).
 func TestStripControl(t *testing.T) {
-	in := "ok\x1b[2J\x07\x7f end"
+	in := "ok\x1b[2J\x07\x7f\u009b\u0080 end"
 	got := stripControl(in)
 	for _, r := range got {
 		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {


### PR DESCRIPTION
## Summary
Unbreaks **main CI**, which has been red since PR #95 (lets-ds6bc) on two independent counts:

### 1. Lint (golangci-lint) — staticcheck ST1018
`cli/internal/statusline/taskfetch_test.go` embedded raw Unicode control bytes (U+009B, U+0080) in the `TestStripControl` literal. Replaced with `` escapes — runtime string and test intent unchanged.

### 2. Build, vet & test — fork bomb under `go test -race ./...`
statusline `Render()` calls `spawnBackgroundFetch` / `spawnBackgroundTaskFetch`, which re-exec `os.Executable()` to refresh caches off the render hot path. Under `go test`, `os.Executable()` is the test binary; re-running it with `statusline --fetch-…` makes Go's flag parser stop at the positional and run the whole suite, so every render test spawns a detached copy that spawns more — an exponential fork bomb. On Linux CI it exhausts the process table and the job dies with SIGTERM (exit 143); on macOS `go test` reports PASS before the explosion is visible (so #95 merged red unnoticed).

Fix: guard both spawners with `backgroundSpawnsDisabled()` (`testing.Testing()`), so they no-op under any test binary while production spawns normally. A regression test pins the guard.

## Verification
- `go build ./...`, `go vet ./...`, `gofmt -l` — clean
- `go test -race ./...` — all packages green, 0 leaked subprocesses
- golangci-lint ST1018 cleared (Lint job green on this branch)

## Task
lets-ijpw4: Fix CI red on main (ST1018 lint + statusline fork-bomb test hang)

---
Generated with LETS plugin