### PR TITLE
fix(lets-vdbhz): context-aware staging in commit skill (drop git add -A)

### DIFF
--- a/plugins/lets/skills/commit/SKILL.md
+++ b/plugins/lets/skills/commit/SKILL.md
@@ -69,11 +69,27 @@ Handle response:
 - **Cancel** -> stop, show LETS box with `/lets:check`
 - **Other** (free text) -> treat as edited commit message, proceed to Step 5
 
-### Step 5: Commit
+### Step 5: Stage (context-aware) & Commit
+
+**NEVER `git add -A` or `git add .`** — they sweep in unrelated changes, untracked cruft, or secrets (`.env`, keys), and clobber a curated staged set. Stage only the reviewed files (see `.claude/rules/git.md`).
+
+Already-staged set wins — if the orchestrator curated files (here or in Step 3), commit exactly those:
 
 ```bash
-git add -A
-git status  # Verify staging
+git diff --staged --quiet && echo "NOTHING_STAGED" || echo "STAGED_OK"
+```
+
+- **`STAGED_OK`** (files already staged) → do NOT run `git add`; commit the existing staged set as-is.
+- **`NOTHING_STAGED`** → stage the specific files reviewed in Step 3 **by name** (never `-A` / `.`):
+
+  ```bash
+  git add <reviewed-file-1> <reviewed-file-2>   # named files only
+  ```
+
+Then commit:
+
+```bash
+git status  # Verify the staged set is exactly what you intend
 git commit -m "<type>($TASK_ID): <description>
 
 Task: $TASK_ID"


### PR DESCRIPTION
## Summary
`plugins/lets/skills/commit/SKILL.md` Step 5 hardcoded `git add -A`, which contradicts `.claude/rules/git.md` (prefer named files; `-A` can sweep in unrelated changes, untracked cruft, or secrets like `.env`/keys, and clobbers a curated staged set). The orchestrator already deviated from the skill in practice (e.g. PR #83) to honor git.md — so the skill text was the thing that needed fixing.

## Change
Step 5 is now context-aware:
- If files are already staged → commit exactly those, no `git add`.
- If nothing is staged → stage the specific files reviewed in Step 3 **by name**.
- Never `git add -A` / `git add .` (kept only as an explicit prohibition).

## Acceptance
- [x] No `git add -A` command in Step 5
- [x] Respects an already-staged set
- [x] Stages reviewed files by name when needed
- [x] Consistent with `.claude/rules/git.md`
- [x] No frontmatter version bump (deferred to release ceremony)

Dogfooded: this commit staged its single file by name.

## Out of scope (follow-up filed)
`plugins/lets/commands/github-pr.md:1031` has the same `git add -A` pattern; a broader audit of plugin bash blocks vs project rules is tracked separately.

## Task
lets-vdbhz

---
Generated with LETS plugin