### PR TITLE
chore: release v0.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lets",
       "source": "./plugins/lets",
       "description": "Development workflow with session management, code review, and task tracking",
-      "version": "0.5.5"
+      "version": "0.6.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 - **Statusline tips now surface the new features (lets-h63lo).** The rotating bottom-line hints in `lets statusline` gained coverage for `--workflow` (off-context fan-out + skeptic finding-verification on `/lets:review` / `/lets:opinion` / `/lets:explore`), `/lets:explore` and its `--no-web`, the `--no-task` / `--no-dir` / `--no-tip` trim flags, and `/lets:note --pre-compact`.
 - **`/lets:end --pre-compact` + shared `pre-compact-note` skill (lets-jvbft).** `/lets:end` gains a `--pre-compact` (alias `--resume`) mode: a pre-compaction snapshot that writes the recovery-grade `## RESUME` comment to the active task plus a session-summary file, then returns WITHOUT ending the session (no push, no task-status prompt) so you can `/compact` and keep working in the same window. The resume-snapshot step is extracted into a shared internal `pre-compact-note` skill that `/lets:note --pre-compact` now delegates to as well — single source of truth, no template drift.
 
+### Fixed
+- **Commit skill stages context-aware (lets-vdbhz).** `/lets:commit` no longer runs a blanket `git add -A`, which could sweep in unrelated changes, untracked cruft, or secrets (`.env`, keys) and clobber a curated staged set. Step 5 now respects an already-staged set as-is, otherwise stages the reviewed files by name — consistent with `.claude/rules/git.md`.
+
 ## [0.5.5] - 2026-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-05
+
 ### Added
 - **`/lets:explore` — topic-exploration command + `--workflow` (lets-odo4o).** Extracted from `/lets:brainstorm` into its own command: a scout gathers project context, an always-on Web Research stage pulls CURRENT community standards via WebSearch/WebFetch, then parallel domain agents surface insights, open questions, and approaches grounded in that brief. `--workflow` runs the fan-out off-context via a Dynamic Workflow (web research → ideate → semantic cluster); `--no-web` skips the web stage; an off-project guard handles topics unrelated to the repo. The cluster stage semantically merges convergent ideas across agents (real multi-agent attribution, title-only fallback). `/lets:brainstorm` is now backlog-only (3 modes).
 - **`/lets:review --workflow` + adversarial finding-verification (lets-odo4o).** Opt-in off-context Dynamic Workflow variant; every `[BLOCKER]`/`[SUGGESTION]` is refuted by `lets:skeptic` agents before being reported (asymmetric drop rule). Verification runs in both standard and `--workflow` modes — `--workflow` is a pure off-context performance lever.
@@ -422,7 +424,8 @@ Initial release with expert agents team.
 - SessionStart hook injecting workflow rules
 - Plugin structure: commands, agents, hooks
 
-[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.5.5...HEAD
+[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/restarter/lets-workflow/compare/v0.5.5...v0.6.0
 [0.5.5]: https://github.com/restarter/lets-workflow/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/restarter/lets-workflow/compare/v0.5.3...v0.5.4
 [0.5.3]: https://github.com/restarter/lets-workflow/compare/v0.5.2...v0.5.3

--- a/plugins/lets/.claude-plugin/plugin.json
+++ b/plugins/lets/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "author": {
     "name": "restarter",
     "url": "https://github.com/restarter"

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.5.5
+version: 0.6.0
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->


### PR DESCRIPTION
## Release v0.6.0

Phase 1 bump: version 0.5.5 → 0.6.0 across `plugin.json`, `marketplace.json`, `lets-rules.md` frontmatter; `CHANGELOG.md` `[Unreleased]` promoted to `## [0.6.0]` with a fresh empty `[Unreleased]` and updated compare links. Gates passed locally (`make test` -race, `make build`, `verify-versions`).

### Highlights (full notes in CHANGELOG `[0.6.0]`)
- **Dynamic Workflows + `--workflow`** on `/lets:review`, `/lets:opinion`, `/lets:explore` (off-context fan-out) + adversarial finding-verification via `lets:skeptic` (lets-odo4o).
- **`/lets:explore`** topic-exploration command extracted from brainstorm, with an always-on web-research stage.
- **Rich statusline is the default** — boxed multi-line, cell-accurate, escape-injection hardened, `--no-dir`/`--no-task`/`--no-tip` trims (lets-ds6bc).
- **`/lets:note --pre-compact` + `/lets:end --pre-compact`** — recovery-grade session snapshots before `/compact`, via a shared `pre-compact-note` skill (lets-lwut3, lets-jvbft).
- **Statusline tips** now surface the new features (lets-h63lo).
- **Fixed:** `/lets:commit` context-aware staging (drop blanket `git add -A`) (lets-vdbhz).

### After merge
Phase 3: `git checkout main && git pull && make release-tag VERSION=0.6.0` (tag push triggers goreleaser).

---
Generated with LETS plugin