### PR TITLE
chore: release v0.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lets",
       "source": "./plugins/lets",
       "description": "Development workflow with session management, code review, and task tracking",
-      "version": "0.6.0"
+      "version": "0.6.1"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-05
+
 ### Added
 - **`/lets:plan-workflow` — autonomous planning Dynamic Workflow, PREVIEW (lets-y3aic).** A standalone preview command that runs whole-command planning off-context: you give a goal + a rubric up front, and the workflow explores, proposes approaches, architects each, judges them against your rubric, evaluates the winner, and writes a plan — you approve at the end (steer-by-rubric, not gate-each-step). Shipped standalone to dogfood across projects before it folds into native `/lets:plan --workflow` (lets-jsw00); experimental, expect rough edges. The interactive native `/lets:plan` is untouched.
 
@@ -427,7 +429,8 @@ Initial release with expert agents team.
 - SessionStart hook injecting workflow rules
 - Plugin structure: commands, agents, hooks
 
-[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/restarter/lets-workflow/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/restarter/lets-workflow/compare/v0.5.5...v0.6.0
 [0.5.5]: https://github.com/restarter/lets-workflow/compare/v0.5.4...v0.5.5
 [0.5.4]: https://github.com/restarter/lets-workflow/compare/v0.5.3...v0.5.4

--- a/plugins/lets/.claude-plugin/plugin.json
+++ b/plugins/lets/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "restarter",
     "url": "https://github.com/restarter"

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.6.0
+version: 0.6.1
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->


### PR DESCRIPTION
## Release v0.6.1

Patch release: ships the **`/lets:plan-workflow` preview** command (#104) that didn't make 0.6.0.

Phase 1 bump: 0.6.0 → 0.6.1 across `plugin.json`, `marketplace.json`, `lets-rules.md` frontmatter; `CHANGELOG.md` `[Unreleased]` → `## [0.6.1]`. Gates passed locally.

### What's new
- **`/lets:plan-workflow` (PREVIEW)** — standalone autonomous-planning Dynamic Workflow (goal + rubric, off-context, approve-at-end), shipped so it can be dogfooded across projects before folding into native `/lets:plan --workflow` (lets-jsw00). Experimental — expect rough edges. The interactive native `/lets:plan` is untouched.

### After merge
Phase 3: `git checkout main && git pull && make release-tag VERSION=0.6.1`.

---
Generated with LETS plugin