### PR TITLE
feat(lets-fe788): date-prefix plan filenames and align plan lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Plan filenames are date-prefixed + plan lookups are slug-scoped (lets-fe788).** `/lets:plan` now saves plans as `.lets/plans/YYYY-MM-DD-HHMM-<slug>.md` (same convention as `.lets/sessions/`), so a second plan on the same branch no longer overwrites the first — plan history is preserved. The three readers — `/lets:execute`, `/lets:review --plan`, `/lets:check --plan` — resolve the latest plan slug-scoped (`ls -t .lets/plans/*<slug>*.md | head -1`) instead of a global latest, fixing cross-worktree shadowing where the symlink-shared `.lets/plans/` made `ls -t *.md` grab another worktree session's plan. Each reader has an empty-slug guard (prevents the glob collapsing back to global latest), a task-id fallback, and `/lets:review --plan` now calls detect-task in plan mode so the fallback resolves. Legacy bare-name plans still resolve (wildcard matches both formats).
+
 ## [0.6.1] - 2026-06-05
 
 ### Added

--- a/plugins/lets/commands/check.md
+++ b/plugins/lets/commands/check.md
@@ -56,12 +56,20 @@ If `--plan` flag detected, switch to plan review mode. Skip all code review step
 
 ```bash
 LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
-# Find latest plan
-PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*.md 2>/dev/null | head -1)
-# Or specific path: /lets:check --plan path/to/plan.md
+BRANCH=$(git branch --show-current)
+SLUG="${BRANCH#feature/}"
+PLAN=""
+# Guard: empty slug (detached HEAD) would collapse the glob to *.md -> global latest -> another
+# worktree's plan (the bug this fixes). Skip to the explicit-path hint instead.
+if [ -n "$SLUG" ]; then
+  # Latest plan for THIS branch/slug - matches date-prefixed (YYYY-MM-DD-HHMM-<slug>.md) and legacy
+  # bare <slug>.md. Slug-scoped, NOT global `ls -t`: .lets/plans is shared across worktrees via symlink.
+  PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"${SLUG}"*.md 2>/dev/null | head -1)
+fi
+# Explicit path wins: /lets:check --plan path/to/plan.md
 ```
 
-If no plan found: "No plans found in `.lets/plans/`. Run `/lets:brainstorm` first."
+If no plan found: "No plan found for this branch in `.lets/plans/`. Run `/lets:plan` first, or pass a path: `/lets:check --plan <path>`." (Trunk-mode on `{LETS_MERGE_BRANCH}`: the slug is the branch name and won't match a `<task-id>` plan - use the explicit path or `/lets:review --plan`.)
 
 Read the plan and review with 5 lenses (same confidence filter):
 

--- a/plugins/lets/commands/execute.md
+++ b/plugins/lets/commands/execute.md
@@ -44,18 +44,30 @@ AskUserQuestion(
 LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
 BRANCH=$(git branch --show-current)
 
-# Trunk-mode: primary lookup is task-id (plan.md saves as <task-id>.md when HEAD == merge-branch)
+# Derive slug: trunk-mode uses task-id (plan.md saves <date>-<task-id>.md on the merge-branch);
+# otherwise the branch slug (covers feature/* and worktree-* branches).
+# ${TASK_ID} is substituted by the orchestrator from the Step 1 detect-task result.
 if [ "$BRANCH" = "{LETS_MERGE_BRANCH}" ]; then
-  cat "$LETS_PROJECT_ROOT/.lets/plans/${TASK_ID}.md" 2>/dev/null
+  SLUG="${TASK_ID}"
+else
+  SLUG="${BRANCH#feature/}"
 fi
 
-# Standard lookup (also covers feature/* + worktrees)
-SLUG=${BRANCH#feature/}
-cat "$LETS_PROJECT_ROOT/.lets/plans/${SLUG}.md" 2>/dev/null
-cat "$LETS_PROJECT_ROOT/.lets/plans/${BRANCH}.md" 2>/dev/null
+# Guard: an empty slug (detached HEAD, or unresolved task-id in trunk-mode) would collapse the
+# glob to *.md -> global latest -> another worktree's plan (the exact bug this task fixes).
+if [ -z "$SLUG" ]; then
+  echo "Could not derive a plan slug (detached HEAD or unresolved task-id). Pass a path or run /lets:start."
+else
+  # Latest plan for this slug - matches date-prefixed (YYYY-MM-DD-HHMM-<slug>.md) AND legacy bare
+  # <slug>.md. Slug-scoped, NOT global latest: .lets/plans is shared across worktrees via symlink.
+  PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"${SLUG}"*.md 2>/dev/null | head -1)
+  # Fallback: match by task-id (catches trunk-mode plans + naming drift, e.g. plan-workflow output)
+  if [ -z "$PLAN" ] && [ -n "${TASK_ID}" ]; then
+    PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"${TASK_ID}"*.md 2>/dev/null | head -1)
+  fi
+fi
 
-# Wildcard fallback: match by task-id (catches trunk-mode plans + naming drift)
-ls "$LETS_PROJECT_ROOT/.lets/plans/"*${TASK_ID}* 2>/dev/null
+[ -n "$PLAN" ] && cat "$PLAN"
 ```
 
 If no plan found:
@@ -70,8 +82,12 @@ If argument is `--status`:
 ```bash
 LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
 BRANCH=$(git branch --show-current)
-# Show plan info
-echo "Plan: .lets/plans/${SLUG}.md"
+# Show plan info (re-resolve: each bash block is a fresh shell). Same guarded lookup as Step 2.
+SLUG=${BRANCH#feature/}; [ "$BRANCH" = "{LETS_MERGE_BRANCH}" ] && SLUG="${TASK_ID}"
+PLAN=""
+[ -n "$SLUG" ] && PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"${SLUG}"*.md 2>/dev/null | head -1)
+[ -z "$PLAN" ] && [ -n "${TASK_ID}" ] && PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"${TASK_ID}"*.md 2>/dev/null | head -1)
+echo "Plan: ${PLAN:-(none found)}"
 bd show <task-id>
 # Show commits since session start
 BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
@@ -84,7 +100,7 @@ fi
 ```
 ## Execution Status: **{task title}** (`{task-id}`)
 
-Plan: .lets/plans/{slug}.md
+Plan: {resolved plan path}
 Commits this session: {N}
 
 {commit list}
@@ -173,9 +189,15 @@ The plan file provides the roadmap; explicit user approval provides the gates.
 After implementation is complete (all plan tasks done):
 
 ```bash
+LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
+BRANCH=$(git branch --show-current)
+SLUG=${BRANCH#feature/}; [ "$BRANCH" = "{LETS_MERGE_BRANCH}" ] && SLUG="${TASK_ID}"
+PLAN=""; [ -n "$SLUG" ] && PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"${SLUG}"*.md 2>/dev/null | head -1)
+BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
+START_REF=$(cat "$LETS_PROJECT_ROOT/.lets/sessions/.session-start-ref-${BRANCH_SLUG}" 2>/dev/null)
 bd comments add <task-id> "## Plan execution complete $(date +%Y-%m-%d)
 
-Plan: .lets/plans/${SLUG}.md
+Plan: ${PLAN:-(none found)}
 Commits: $(git log --oneline ${START_REF}..HEAD | wc -l | tr -d ' ')
 
 $(git log --oneline ${START_REF}..HEAD)"

--- a/plugins/lets/commands/plan-workflow.md
+++ b/plugins/lets/commands/plan-workflow.md
@@ -64,7 +64,8 @@ Aggregate: `{ plan_markdown, delivered_approach, diverged_from_winner, divergenc
   ```bash
   LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
   mkdir -p "$LETS_PROJECT_ROOT/.lets/plans"
-  # write to .lets/plans/$(date +%Y-%m-%d-%H%M)-<slug>.md
+  # Same naming contract as /lets:plan (lets-fe788): STAMP=$(date +%Y-%m-%d-%H%M);
+  # write to .lets/plans/${STAMP}-<slug>.md  (slug = task-id-based descriptor for this run).
   ```
 - Show the **decision log** (winner + judge votes/totals + rationale), the approach list, the eval findings, and the plan summary.
 - User approves -> suggest `/lets:execute`. Wants changes -> adjust the rubric and re-run (`Workflow` `resumeFromRunId` caches completed stages while you iterate the script).

--- a/plugins/lets/commands/plan.md
+++ b/plugins/lets/commands/plan.md
@@ -717,13 +717,16 @@ if [ "$BRANCH" = "{LETS_MERGE_BRANCH}" ]; then
 else
   SLUG="${BRANCH#feature/}"   # e.g., 0nf.10-improve-brainstorm
 fi
+STAMP=$(date +%Y-%m-%d-%H%M)   # same convention as .lets/sessions/ - keeps plan history, no overwrite
 mkdir -p "$LETS_PROJECT_ROOT/.lets/plans"
+PLAN_FILE="$LETS_PROJECT_ROOT/.lets/plans/${STAMP}-${SLUG}.md"
+echo "$PLAN_FILE"   # capture the exact dated path - this is where you Write the plan
 ```
 
-Write plan to: `.lets/plans/{branch-slug}.md`
+Write plan to: `$PLAN_FILE` (i.e. `.lets/plans/${STAMP}-${SLUG}.md`)
 
-Example: branch `feature/0nf.10-improve-brainstorm` -> `.lets/plans/0nf.10-improve-brainstorm.md`
-Trunk-mode example: branch `main`, task `lets-abc` -> `.lets/plans/lets-abc.md`
+Example: branch `feature/0nf.10-improve-brainstorm` -> `.lets/plans/2026-06-06-1846-0nf.10-improve-brainstorm.md`
+Trunk-mode example: branch `main`, task `lets-abc` -> `.lets/plans/2026-06-06-1846-lets-abc.md`
 
 ### Record in Beads
 
@@ -734,7 +737,7 @@ bd comments add <task-id> "## Plan: {feature name}
 Approach: {chosen option name}
 Tasks: {N} implementation tasks
 Key files: {top 3-5 files}
-Plan: .lets/plans/${SLUG}.md"
+Plan: .lets/plans/${STAMP}-${SLUG}.md"
 ```
 
 ### Show Output
@@ -742,7 +745,7 @@ Plan: .lets/plans/${SLUG}.md"
 ```
 ## Plan Ready: **{task title}** (`{task-id}`)
 
-Saved: `.lets/plans/{branch-slug}.md`
+Saved: `.lets/plans/${STAMP}-${SLUG}.md`
 Built: {full flow (explorer + architect + expert agents) | fast mode (orchestrator-only - no subagents)}
 
 ### Approach

--- a/plugins/lets/commands/review.md
+++ b/plugins/lets/commands/review.md
@@ -609,17 +609,37 @@ bd comments add <task-id> "Code review ({PR #X | local}): {verdict}. {N} issues 
 
 ### P1: Load Plan
 
+Use the **detect-task** skill to find the active task: `Skill(skill: "lets:detect-task")`. Plan mode skips the code-review detect-task call below, so resolve the id here; the orchestrator substitutes it for `{task-id}`.
+
 ```bash
 LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
-
-# If path provided: use it
-# If no path: derive from branch name
 BRANCH=$(git branch --show-current)
-SLUG=${BRANCH#feature/}
-cat "$LETS_PROJECT_ROOT/.lets/plans/${SLUG}.md" 2>/dev/null
 
-# Fallback: glob match by task-id
-ls "$LETS_PROJECT_ROOT/.lets/plans/"*{task-id}* 2>/dev/null
+# If a path was provided to --plan, use it directly and skip this derivation.
+
+# Derive slug: trunk-mode uses task-id; otherwise the branch slug.
+# {task-id} is substituted by the orchestrator from the detect-task result above.
+if [ "$BRANCH" = "{LETS_MERGE_BRANCH}" ]; then
+  SLUG="{task-id}"
+else
+  SLUG="${BRANCH#feature/}"
+fi
+
+# Guard: empty slug would collapse the glob to *.md -> global latest -> another worktree's plan
+# (the bug this task fixes). Bail to the no-plan message instead.
+if [ -z "$SLUG" ]; then
+  PLAN=""
+else
+  # Latest plan for this slug - date-prefixed or legacy bare name. Slug-scoped (shared .lets
+  # across worktrees via symlink, so global latest would grab another branch's plan - lets-fe788).
+  PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"${SLUG}"*.md 2>/dev/null | head -1)
+  # Fallback: glob match by task-id (catches trunk-mode plans + naming drift)
+  if [ -z "$PLAN" ] && [ -n "{task-id}" ]; then
+    PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"{task-id}"*.md 2>/dev/null | head -1)
+  fi
+fi
+
+[ -n "$PLAN" ] && cat "$PLAN"
 ```
 
 If no plan files found, inform user and exit:


### PR DESCRIPTION
## Summary
Plans saved to `.lets/plans/{branch-slug}.md` overwrote each other (no history), and the "latest plan" lookups used a global `ls -t | head -1` that grabbed another worktree's plan because `.lets/` is symlinked across worktrees (demonstrated live: `/lets:check --plan`'s global lookup returned a different branch's plan). This adopts the session-style `YYYY-MM-DD-HHMM-<slug>.md` naming and switches all readers to slug-scoped latest-by-mtime.

## Changes
- **`/lets:plan`** writer: date-prefix the saved plan filename via `STAMP=$(date +%Y-%m-%d-%H%M)`, echo the resolved path
- **`/lets:execute`, `/lets:review --plan`, `/lets:check --plan`** readers: slug-scoped `ls -t .lets/plans/*<slug>*.md | head -1` + task-id fallback + empty-slug guard (prevents the glob collapsing back to global latest)
- **`/lets:review --plan`**: calls detect-task in plan mode so the `{task-id}` fallback resolves (plan mode skips the code-review detect-task)
- **`/lets:plan-workflow`**: consistency comment (already on the target format)
- Backward-compatible: legacy bare-name plans still resolve (wildcard matches both formats); existing plans untouched

## Task
lets-fe788: Date-prefix plan filenames and align plan lookups across commands

---
Generated with LETS plugin