### PR TITLE
chore: release v0.6.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "lets",
       "source": "./plugins/lets",
       "description": "Development workflow with session management, code review, and task tracking",
-      "version": "0.6.1"
+      "version": "0.6.2"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-06-06
+
 ### Added
 - **cmux as an optional macOS worktree launcher (lets-3jutw).** A new `LETS_LAUNCHER` config key (`terminal` default | `cmux`, asked by `/lets:init`) lets `/lets:worktree create` open the new worktree session inside a [cmux](https://github.com/manaflow-ai/cmux) workspace running `claude '/lets:start <id>'` — one command instead of opening a second terminal — with a readable workspace slug derived from the task title. Backed by a `lets cmux` Go subcommand (`open` + `rename`, `//go:build unix`, Windows stub) that wraps `cmux workspace create/list/rename`. **Strictly optional and never hard-fails:** it detects cmux on PATH + macOS and silently falls back to the `cd … && claude` terminal flow when absent, so non-macOS / no-cmux setups are unchanged. `open` carries a duplicate-session guard (refuses a second workspace for a worktree that already has one — `--force` overrides), and `lets cmux rename` lets a session relabel its own tab to disambiguate concurrent sessions. Override per-run with `/lets:worktree create <name> --cmux` / `--no-cmux`.
 - **`/lets:backlog` — backlog review + cleanup command (lets-9r4at).** Extracted from `/lets:brainstorm`: a two-mode command (`/lets:backlog review` | `/lets:backlog cleanup`, or a menu when called bare). *Review* launches an explorer scout + parallel domain agents that ideate over the backlog and aggregate multi-perspective insights (the former brainstorm Heavy mode, moved verbatim); *Cleanup* is fast interactive triage of stale/duplicate/orphan/unassigned tasks (no agents). Continues the decomposition started when `/lets:explore` was split out for topic ideation.
@@ -444,7 +446,8 @@ Initial release with expert agents team.
 - SessionStart hook injecting workflow rules
 - Plugin structure: commands, agents, hooks
 
-[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.6.1...HEAD
+[Unreleased]: https://github.com/restarter/lets-workflow/compare/v0.6.2...HEAD
+[0.6.2]: https://github.com/restarter/lets-workflow/compare/v0.6.1...v0.6.2
 [0.6.1]: https://github.com/restarter/lets-workflow/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/restarter/lets-workflow/compare/v0.5.5...v0.6.0
 [0.5.5]: https://github.com/restarter/lets-workflow/compare/v0.5.4...v0.5.5

--- a/plugins/lets/.claude-plugin/plugin.json
+++ b/plugins/lets/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lets",
   "description": "Development workflow with session management, code review, and task tracking",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "author": {
     "name": "restarter",
     "url": "https://github.com/restarter"

--- a/plugins/lets/rules/lets-rules.md
+++ b/plugins/lets/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.6.1
+version: 0.6.2
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->


### PR DESCRIPTION
## Release v0.6.2

Bumps plugin.json + marketplace.json + lets-rules.md frontmatter to 0.6.2 and promotes CHANGELOG [Unreleased] -> [0.6.2].

### Highlights (merged since v0.6.1)
**New commands / features**
- `/lets:backlog` (+ `review --workflow`) - backlog review + cleanup, extracted from `/lets:brainstorm` (#109)
- `/lets:review-round` - work through a RECEIVED review round, inverse of `/lets:review` (#110)
- `/lets:start --main` - no-task project-assistant / PM mode (#112)
- cmux as an optional macOS worktree launcher + `LETS_LAUNCHER` config key (#111)

**Changed / Fixed**
- `/lets:brainstorm` slimmed to Quick-only ideation (#109)
- Date-prefixed plan filenames + slug-scoped plan lookups (fixes cross-worktree shadowing) (#108)
- `/lets:update` status table: in-sync vs up-to-date; `lets update --json` schema_version=2 (#107)
- Light-theme statusline pill softened (#113)

Gates green locally: `make test` (race), `make build`, `verify-versions.sh` (source-tree == 0.6.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)