### PR TITLE
fix(lets-nl0ks): nudge light-theme pill back to a visible label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Light-theme statusline pill nudged back to a visible label (lets-nl0ks).** The light-palette pill background shipped in 0.6.2 (`246,243,237`) blended too far into a white terminal — the location/worktree label all but disappeared. Moved it back toward visible (`246,243,237` → `238,234,225` / `#EEEAE1`) so the pill reads as a small but present label, without returning to the heavy `230,226,216` block. Dark palette unchanged.
+
 ## [0.6.2] - 2026-06-06
 
 ### Added

--- a/cli/internal/statusline/rich.go
+++ b/cli/internal/statusline/rich.go
@@ -74,7 +74,7 @@ var paletteLight = palette{
 	label:  "\033[38;2;107;113;133m",
 	dim:    "\033[38;2;154;159;176m",
 	sep:    "\033[38;2;213;209;198m",
-	pillBg: "\033[48;2;246;243;237m",
+	pillBg: "\033[48;2;238;234;225m",
 }
 
 // Glyphs — universal Unicode/emoji set that renders on macOS and Linux without


### PR DESCRIPTION
## Summary
The light-palette statusline pill background shipped in v0.6.2 (`246,243,237`) blended too far into a white terminal — the location/worktree label all but disappeared. This nudges it back toward visible: `246,243,237` → `238,234,225` (`#EEEAE1`), so the pill reads as a small but present label, without returning to the heavier `230,226,216` block from 0.6.1.

Dark palette unchanged.

Continues lets-nl0ks (light-theme support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)