### PR TITLE
fix(lets-u06sc): auto-resolve task-id plan slug in trunk-mode for /lets:check --plan

### DIFF
--- a/.claude/rules/lets-rules.md
+++ b/.claude/rules/lets-rules.md
@@ -1,6 +1,6 @@
 ---
 name: lets-rules
-version: 0.6.3
+version: 0.6.4
 ---
 
 <!-- DO NOT EDIT - managed by lets init / lets install. To add custom rules, create a sibling *.md file in this directory (e.g. .claude/rules/team-conventions.md). Files prefixed `lets-` are owned by the LETS plugin and overwritten on update. -->
@@ -34,7 +34,7 @@ If a `## LETS Notice` block appears in the injected context (sibling H2 of `## L
   **Exception — trunk-mode.** If `detect-task` returns an active task AND HEAD == `$LETS_MERGE_BRANCH`, trunk-mode is active (user opted in via the `take-task` picker option "Stay on current branch"). In trunk-mode: editing the merge-branch is allowed; `/lets:done` pushes + closes the task without creating a PR (same-source-target is not a valid PR); `/lets:plan` and `/lets:execute` derive plan filenames from task-id instead of branch slug. If HEAD == `$LETS_MERGE_BRANCH` AND `detect-task` returns None, the default rule applies — refuse edits, instruct user to run `/lets:start <id>` first.
 
   **Main / assistant mode.** When the session was entered via `/lets:start --main` (alias `--assistant`), HEAD == `$LETS_MERGE_BRANCH` with no active task is the **intended** state (read + triage), not an error — do not refuse the session or demand a task. The refuse-edits rule still governs *code edits*: on edit-intent, route the user to `take-task` / `create-task` (graceful hand-off) instead of only refusing.
-- **Never edit installed `lets-*` rules files** in `.claude/rules/`. They are plugin-managed copies refreshed by `/lets:init`. Edit the canonical source `plugins/lets/rules/lets-*.md` in the plugin instead — direct edits to installed copies bypass drift detection and silently desync from source.
+- **Never edit installed `lets-*` rules files** in `.claude/rules/` or `~/.claude/rules/`. They are plugin-managed copies refreshed by `/lets:init` / `/lets:update` (project) and `lets init --user` / `/lets:update` (global). Edit the canonical source `plugins/lets/rules/lets-*.md` in the plugin instead — direct edits to installed copies bypass drift detection and silently desync from source.
 
 ## Slash Command Discipline
 
@@ -174,7 +174,8 @@ AUTO MODE (autonomous execution: `/loop`, `/lets:execute --auto`, `/lets:team` p
 
 ## Agent Rules
 
-- When launching expert agents for `/lets:review`, `/lets:github-pr`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:backlog`, `/lets:explore` - use ONLY `lets:*` agents (`lets:architect`, `lets:security`, etc.)
+- When launching expert agents for `/lets:review`, `/lets:github-pr`, `/lets:opinion`, `/lets:ask`, `/lets:plan`, `/lets:backlog`, `/lets:research` - use ONLY `lets:*` agents (`lets:architect`, `lets:security`, etc.)
+- **Carve-out for web data-gatherers:** `/lets:research`'s per-sub-question web fetchers are data gatherers using the default web-capable subagent, NOT expert dispatch - `lets:*` agents have `tools: Read, Grep, Glob, Bash` and no web tools. The lets:*-only rule covers research's `lets:skeptic` cross-check, not its web fetch.
 - `lets:actor` is a special meta-agent: requires explicit user request + personality source (URL or file path). Never auto-select. Use `actor-fetch-personality` skill to fetch personality before dispatch.
 - Never use `general-purpose` or other non-lets subagent types for expert work
 
@@ -428,19 +429,18 @@ This applies when: presenting implementation approaches, choosing between soluti
 | `/lets:review-round` | Code | Work through a RECEIVED review round - triage N comments, decisions->task, artifact FROZEN, one final edit-pass (inverse of `/lets:review`) |
 | `/lets:opinion` | Expert | Technical decision (dynamic agent count; `--workflow` = off-context fan-out + adversarial challenge) |
 | `/lets:ask` | Expert | Quick expert consultation (1 agent) |
-| `/lets:brainstorm` | Planning | Quick interactive ideation on a topic - fast context scan, no agents |
-| `/lets:backlog` | Planning | Backlog review (multi-agent) + interactive cleanup triage |
-| `/lets:explore` | Planning | Explore a topic from multiple expert angles (`--workflow` = off-context ideate fan-out) |
+| `/lets:research` | Expert | Web-sourced CITED answer to an external/technical question; cross-check pass flags single-source/contradicted/stale claims (`--workflow` = off-context; `--project` = repo-grounded) *(ships next release)* |
+| `/lets:backlog` | Planning | Backlog review (multi-agent; `--workflow` = off-context) + `--fast` quick no-agent pulse + interactive cleanup triage |
 | `/lets:plan` | Planning | Structured planning with agents - architecture + implementation plan (`--fast` = orchestrator-only, skips explorer/architect/expert subagents) |
-| `/lets:plan-workflow` | Planning | **PREVIEW** - autonomous planning via a Dynamic Workflow (goal + rubric up front, off-context, approve at end); folds into native `/lets:plan` later (lets-jsw00) |
+| `/lets:plan-workflow` | Planning | **PREVIEW** - autonomous planning via a Dynamic Workflow (goal + rubric up front, off-context, approve at end); folds into native `/lets:plan` later (lets-jsw00); `--fast` = lean budget (~7 agents, still off-context, heavy review pass skipped, quick plan-check kept) - distinct from `/lets:plan --fast` (orchestrator-only, no subagents) |
 | `/lets:execute` | Planning | Execute plan from /lets:plan via native plan mode |
 | `/lets:status` | Utility | Task overview and project status |
 | `/lets:worktree` | Utility | Create/manage interactive worktrees for parallel work |
 | `/lets:statusline` | Utility | Manage & persist statusline appearance - light/dark, compact, hidden rows (writes personal `.claude/settings.local.json`) *(ships next release)* |
 | `/lets:team` | Utility | Parallel implementation with Agent Teams (run, status, stop) |
 | `/lets:note` | Utility | Add note to active task (`--pre-compact` = resume snapshot before /compact) |
-| `/lets:init`    | Setup | Per-project initialization. Re-run for self-heal (drift fix) or to change config |
-| `/lets:update`  | Setup | Sync project with the current release - `.lets/.env` + rules self-heal, plus version status for the `lets` binary and the plugin |
+| `/lets:init`    | Setup | Per-project initialization. Re-run for self-heal (drift fix) or to change config; offers the user-scope global-rules install (`lets init --user`) when the plugin is user-scoped *(ships next release)* |
+| `/lets:update`  | Setup | Sync project with the current release - `.lets/.env` + rules self-heal, plus version status for the `lets` binary and the plugin, plus the user-level global rules when installed *(ships next release)* |
 
 ### Auto-triggered Skills
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **`/lets:check --plan` finds trunk-mode plans (lets-u06sc).** In trunk-mode (on the merge-branch) the plan lookup used the branch slug (`main`), which never matched `plan.md`'s `<date>-<task-id>.md` save name — forcing a manual `--plan <path>` every time. It now calls detect-task in plan mode and derives the slug from the task-id (with a task-id fallback glob), mirroring `/lets:execute` and `/lets:review --plan` (which already did this).
+
 ## [0.6.4] - 2026-06-12
 
 ### Added

--- a/plugins/lets/commands/check.md
+++ b/plugins/lets/commands/check.md
@@ -54,22 +54,40 @@ Parse the argument(s):
 
 If `--plan` flag detected, switch to plan review mode. Skip all code review steps below.
 
+If no path was passed to `--plan`, use the **detect-task** skill to find the active task: `Skill(skill: "lets:detect-task")` - the orchestrator substitutes its id for `{task-id}` below, so trunk-mode resolves the plan by task-id (not the branch name).
+
 ```bash
 LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
 BRANCH=$(git branch --show-current)
-SLUG="${BRANCH#feature/}"
 PLAN=""
-# Guard: empty slug (detached HEAD) would collapse the glob to *.md -> global latest -> another
-# worktree's plan (the bug this fixes). Skip to the explicit-path hint instead.
-if [ -n "$SLUG" ]; then
-  # Latest plan for THIS branch/slug - matches date-prefixed (YYYY-MM-DD-HHMM-<slug>.md) and legacy
-  # bare <slug>.md. Slug-scoped, NOT global `ls -t`: .lets/plans is shared across worktrees via symlink.
-  PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"${SLUG}"*.md 2>/dev/null | head -1)
+
+# Explicit path wins: /lets:check --plan path/to/plan.md - use it directly and skip this derivation.
+
+# Derive slug: trunk-mode uses task-id (plan.md saves <date>-<task-id>.md on the merge-branch);
+# otherwise the branch slug (covers feature/* and worktree-* branches).
+# {task-id} is substituted by the orchestrator from the detect-task result above.
+if [ "$BRANCH" = "{LETS_MERGE_BRANCH}" ]; then
+  SLUG="{task-id}"
+else
+  SLUG="${BRANCH#feature/}"
 fi
-# Explicit path wins: /lets:check --plan path/to/plan.md
+
+# Guard: empty slug (detached HEAD, or unresolved task-id in trunk-mode) would collapse the glob
+# to *.md -> global latest -> another worktree's plan (the bug this fixes).
+if [ -z "$SLUG" ]; then
+  PLAN=""
+else
+  # Latest plan for THIS slug - matches date-prefixed (YYYY-MM-DD-HHMM-<slug>.md) and legacy bare
+  # <slug>.md. Slug-scoped, NOT global `ls -t`: .lets/plans is shared across worktrees via symlink.
+  PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"${SLUG}"*.md 2>/dev/null | head -1)
+  # Fallback: glob match by task-id (catches trunk-mode plans + naming drift, e.g. plan-workflow output)
+  if [ -z "$PLAN" ] && [ -n "{task-id}" ]; then
+    PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"{task-id}"*.md 2>/dev/null | head -1)
+  fi
+fi
 ```
 
-If no plan found: "No plan found for this branch in `.lets/plans/`. Run `/lets:plan` first, or pass a path: `/lets:check --plan <path>`." (Trunk-mode on `{LETS_MERGE_BRANCH}`: the slug is the branch name and won't match a `<task-id>` plan - use the explicit path or `/lets:review --plan`.)
+If no plan found: "No plan found for this branch in `.lets/plans/`. Run `/lets:plan` first, or pass a path: `/lets:check --plan <path>`."
 
 Read the plan and review with 5 lenses (same confidence filter):
 


### PR DESCRIPTION
## Summary
In trunk-mode (HEAD == `$LETS_MERGE_BRANCH`, e.g. on `main`), `/lets:check --plan` derived the plan slug from the branch name (`main`), which never matched `plan.md`'s trunk-mode save name `<date>-<task-id>.md` — so it always reported "no plan" and forced a manual `--plan <path>`. Recurring annoyance.

## Fix
`plugins/lets/commands/check.md` Plan Mode now mirrors `/lets:execute` and `/lets:review --plan`:
- calls the **detect-task** skill in plan mode,
- derives `SLUG={task-id}` when on the merge-branch (else the branch slug),
- adds a task-id fallback glob,
- keeps the empty-slug guard, explicit-path-wins, and legacy bare-name match.

`review.md` already had this (shipped in lets-fe788) — only `check.md` was left behind, so this is a one-file change.

## Task
lets-u06sc

---
Generated with LETS plugin