### PR TITLE
refactor(lets-d6vla): remove orphaned jq bindings + fable consistency audit

### DIFF
--- a/cli/internal/initcmd/trackerrules_test.go
+++ b/cli/internal/initcmd/trackerrules_test.go
@@ -178,12 +178,9 @@ func TestTrackerBeads_BindsBdCommands(t *testing.T) {
 			}
 		}
 	}
-	// The label-group progress mechanism lives in ## Notes (too long for a cell):
-	// /lets:status overview/labels/full depend on it for the NN/MM bars - the B2
-	// branch-review regression (main's 3ad2a05 --all fix must not drift out again).
-	if !strings.Contains(content, "bd list --label <label> --json --all") {
-		t.Error(`tracker-beads.md: Notes must carry the label-group binding "bd list --label <label> --json --all" (/lets:status NN/MM bars have no other data source)`)
-	}
+	// (The label-group progress + priority-histogram Notes bindings were removed with the
+	// 5-view /lets:status dashboards in the orient unification (lets-qsgmd); no command
+	// renders the NN/MM bars now, so there is nothing left to pin here.)
 }
 
 // TestTrackerAdapters_VerbVocabInSync pins the canonical neutral-verb list against

--- a/cli/internal/statusline/rich.go
+++ b/cli/internal/statusline/rich.go
@@ -506,7 +506,7 @@ var tips = []string{
 	"Read the codebase first — match the patterns already there.",
 	"Smallest change that solves the problem — easier to review and revert.",
 	"Branch piling up unrelated work? Split it into separate PRs.",
-	"/lets:status overview is a compact read of the whole board.",
+	"/lets:status is a read-only orient snapshot — where you are, what's next.",
 	"Repeated blocker 3x? Stop patching — find the root cause.",
 	"Keep written artifacts in English, even when we chat in another language.",
 	"/lets:review --file <path> audits an existing file's quality.",

--- a/plugins/lets/commands/execute.md
+++ b/plugins/lets/commands/execute.md
@@ -262,16 +262,24 @@ BRANCH=$(git branch --show-current)
 SLUG=${BRANCH#feature/}; [ "$BRANCH" = "{LETS_MERGE_BRANCH}" ] && SLUG="${TASK_ID}"
 PLAN=""; [ -n "$SLUG" ] && PLAN=$(ls -t "$LETS_PROJECT_ROOT/.lets/plans/"*"${SLUG}"*.md 2>/dev/null | head -1)
 BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
-START_REF=$(sed -n 's/^session: //p' "$LETS_PROJECT_ROOT/.lets/sessions/.task-${BRANCH_SLUG}" 2>/dev/null | head -1 | awk '{print $1}')
+# Plan execution is TASK-scoped (a plan can run across sessions), so anchor on the task boundary
+# start:, NOT session: - session: would under-report every prior session's commits.
+START_REF=$(sed -n 's/^start: //p' "$LETS_PROJECT_ROOT/.lets/sessions/.task-${BRANCH_SLUG}" 2>/dev/null | head -1)
 [ -z "$START_REF" ] && START_REF=$(cat "$LETS_PROJECT_ROOT/.lets/sessions/.session-start-ref-${BRANCH_SLUG}" 2>/dev/null)  # back-compat: legacy session ref
+# Degrade loud - never silently record "Commits: 0" into a durable tracker comment on a missing/bad boundary.
+if printf '%s' "$START_REF" | grep -Eq '^[0-9a-f]{7,40}$' && git rev-parse --verify --quiet "${START_REF}^{commit}" >/dev/null; then
+  COUNT=$(git log --oneline "${START_REF}..HEAD" | wc -l | tr -d ' '); LOG=$(git log --oneline "${START_REF}..HEAD")
+else
+  COUNT="unknown (task boundary not found)"; LOG="(commit range unavailable - no valid start: boundary in .task-${BRANCH_SLUG})"
+fi
 mkdir -p "$LETS_PROJECT_ROOT/.lets/cache"
 cat > "$LETS_PROJECT_ROOT/.lets/cache/exec-complete-<task-id>.md" <<EOF
 ## Plan execution complete $(date +%Y-%m-%d)
 
 Plan: ${PLAN:-(none found)}
-Commits: $(git log --oneline ${START_REF}..HEAD | wc -l | tr -d ' ')
+Commits: ${COUNT}
 
-$(git log --oneline ${START_REF}..HEAD)
+${LOG}
 EOF
 ```
 

--- a/plugins/lets/commands/start.md
+++ b/plugins/lets/commands/start.md
@@ -94,7 +94,7 @@ The orient snapshot (Step 3) already shows In flight + Next up - don't repeat th
 **Every session needs a task.** From the orient snapshot, offer the moves:
 
 > - **Resume** the active task if In flight shows one you want to continue.
-> - **Pick** one from Next up (the top 5 ready - for the full list, `bd ready` or `/lets:backlog`).
+> - **Pick** one from Next up (the top 5 ready - for the full list, `/lets:backlog`, or `bd ready` on beads).
 > - **Create** a new task (the `create-task` skill - tracker `create` verb), or claim an existing one (tracker `set-status=in_progress`).
 
 **If user doesn't want to pick a task** but describes work (e.g., "just want to fix proxy config"):
@@ -173,18 +173,29 @@ You do **NOT** write or edit code in this mode. The moment the user wants to imp
 
 ### Step M1: Orient
 
-Steps 1-2 already ran (sessions, git). Main mode skips `take-task`, so save the **session boundary only** here (so `/lets:end` can still diff the session). Main mode has NO claimed task, so the `.task` file gets `session:` ONLY - never `task:`/`start:`, which would make `.task-main` look like a trunk claim and mis-fire trunk-mode. Then add a one-line backlog pulse:
+Steps 1-2 already ran (sessions, git). Main mode skips `take-task`, so save the **session boundary** here (so `/lets:end` can still diff the session). Main mode claims no task, so it does NOT create a `task:`/`start:` (that would make `.task-main` mis-fire trunk-mode). But it must NOT destroy a live trunk claim either - so it **preserves** any existing `task:`/`start:` (merge-write, like the SessionStart hook) and refreshes only `session:`. A genuine main-mode file (no prior `task:`) stays `session:`-only; a preserved live claim then surfaces through orient below instead of being silently clobbered. Then add a one-line backlog pulse:
 
 ```bash
 LETS_PROJECT_ROOT=$(git rev-parse --show-toplevel)
 BRANCH=$(git branch --show-current); BRANCH_SLUG=$(echo "$BRANCH" | tr '/' '-')
 mkdir -p "$LETS_PROJECT_ROOT/.lets/sessions"
 TASK_FILE="$LETS_PROJECT_ROOT/.lets/sessions/.task-${BRANCH_SLUG}"
+# Preserve an existing live trunk claim (task:/start:) - a full-file session:-only write would
+# destroy it, and its /lets:done would then hard-abort with no start:. Merge-write, like the hook.
+PREV_TASK=""; PREV_START=""
+if [ -f "$TASK_FILE" ]; then
+  PREV_TASK=$(sed -n 's/^task: //p' "$TASK_FILE" | head -1)
+  PREV_START=$(sed -n 's/^start: //p' "$TASK_FILE" | head -1)
+fi
 tmp=$(mktemp "${TASK_FILE}.XXXX")
-printf 'session: %s %s\n' "$(git rev-parse HEAD)" "$CLAUDE_CODE_SESSION_ID" > "$tmp" && mv -f "$tmp" "$TASK_FILE"
+{
+  [ -n "$PREV_TASK" ] && echo "task: $PREV_TASK"
+  [ -n "$PREV_START" ] && echo "start: $PREV_START"
+  printf 'session: %s %s\n' "$(git rev-parse HEAD)" "$CLAUDE_CODE_SESSION_ID"
+} > "$tmp" && mv -f "$tmp" "$TASK_FILE"
 ```
 
-Invoke `Skill(skill: "lets:orient")` - with no active task it degrades to branch + no-task + In flight + Next up + Project, which IS the PM triage surface. Keep it short - point to `bd stats` / `bd blocked` for the deep beads dashboard.
+Invoke `Skill(skill: "lets:orient")` - with no active task it degrades to branch + no-task + In flight + Next up + Project, which IS the PM triage surface. Keep it short - on beads, point to `bd stats` / `bd blocked` for the deep dashboard.
 
 **Guard:** Main mode expects `HEAD == $LETS_MERGE_BRANCH`. If on another branch (a worktree or feature branch - which are task-bound), say so in one line and suggest the normal task flow instead; proceed read-only if the user still wants the overview.
 

--- a/plugins/lets/commands/status.md
+++ b/plugins/lets/commands/status.md
@@ -12,7 +12,7 @@ For working the backlog (pulse / ideas / cleanup) use `/lets:backlog`. To claim 
 
 Invoke `Skill(skill: "lets:orient")` - it renders `## Where you are` / `## In flight` / `## Next up` (and `## Project` counts when the tracker provides them), degrading per tracker (`beads` | `planfix-mcp` | `none`).
 
-If a legacy view argument was passed (`overview` / `ready` / `labels` / `blocked` / `full`), ignore it and note once: "Status is now a single orient snapshot; the old views were removed. Deep beads dashboards live in native `bd stats` / `bd blocked`."
+If a legacy view argument was passed (`overview` / `ready` / `labels` / `blocked` / `full`), ignore it and note once: "Status is now a single orient snapshot; the old views were removed. On beads, deep dashboards live in native `bd stats` / `bd blocked`."
 
 ## Step 2: Footer (Response Footer model)
 

--- a/plugins/lets/rules/tracker-beads.md
+++ b/plugins/lets/rules/tracker-beads.md
@@ -29,7 +29,7 @@ The reference adapter. Binds the neutral verbs to the `bd` CLI - the historical,
 | comment-list   | OPT  | yes | `bd comments <id>` |
 | list-by-status | OPT  | yes | `bd list --status=<status> [--json] [--limit N]`; `--json` exposes `status`/`priority` for parsing. For id-only output, parse `--json` — bd has no `--format=ids` (an unknown `--format` value yields empty output, not an error) |
 | search         | OPT  | yes | `bd search <query>` |
-| ready/stats    | OPT  | yes | `bd ready [--limit N]` (`limit=0` → `--limit 0` = ALL ready tasks; used by `/lets:backlog`) / `bd stats` / `bd blocked` (dep-graph tree) / per-label progress + priority histogram (see Notes) |
+| ready/stats    | OPT  | yes | `bd ready [--limit N]` (`limit=0` → `--limit 0` = ALL ready tasks; used by `/lets:backlog`) / `bd stats` (native totals) / `bd blocked` (dep-graph tree) |
 | label          | OPT  | yes | bare `label` (all project labels, e.g. the `epic:*` set) → `bd label list-all`; `label task=<id>` → `bd label list <id>` (one issue's labels); `label add task=<id> value=<l>` → `bd label add <id> <l>`. The bare verb is `list-all`, NOT `bd label list` (which requires an id and errors without one) |
 | assignee       | OPT  | yes | `bd update <id> --assignee=<name>` |
 | set-field      | OPT  | yes | `set-field task=<id> description-file=<path>` → `bd update <id> --description="$(cat <path>)"` (overwrite); `set-field task=<id> priority=<0-4>` → `bd update <id> --priority=<0-4>` (backlog Reprioritize) |
@@ -40,6 +40,6 @@ beads supports every verb, so nothing degrades. A CORE verb that somehow fails (
 
 ## Notes
 
-- `stats` dashboards (used by `/lets:backlog` + the orient snapshot's optional `## Project` counts): the `bd blocked` dep-graph tree and the priority histogram `bd list --status=open --json | jq -r '.[].priority' | sort | uniq -c | sort -rn` are the beads binding of the `stats`/`ready` views. **Label-group progress** (the per-`epic:*` NN/MM bars): for each label from `bd label list-all`, run `bd list --label <label> --json --all` — `--all` is REQUIRED (closed tasks are part of MM; without it progress % overcounts — the 3ad2a05 fix). An adapter that marks these `absent` → the calling command degrades those sections and tells the user (it does NOT render a broken/empty dashboard).
+- `stats` (used by `/lets:backlog` + the orient snapshot's optional `## Project` counts): `bd stats` gives native status/priority totals (no jq); `bd blocked` gives the dep-graph tree (native, no jq). The old per-`epic:*` label-progress bars and the jq-based priority histogram were removed with the 5-view `/lets:status` dashboards (orient unification, lets-qsgmd) — no command renders them now, so the fragile jq-over-bd-JSON control-char path is gone from the adapter.
 - `memory` (`bd remember`) and `dependencies`-write (`bd dep add`) exist in beads but no LETS command calls them, so they are not part of the neutral contract.
 - State-changing ops (`bd close`, `bd update --status`, `bd dolt push`) stay gated under AUTO MODE per the workflow rules.

--- a/plugins/lets/skills/take-task/SKILL.md
+++ b/plugins/lets/skills/take-task/SKILL.md
@@ -55,7 +55,7 @@ AskUserQuestion(
 Handle response:
 - **Stash** -> `git stash`, proceed with branch switch, remind to `git stash pop` later
 - **Commit first** -> delegate to commit skill, then proceed with branch switch
-- **Stay** -> skip branch switch, warn about mixed work. Stop here.
+- **Stay** -> skip branch switch, warn about mixed work, then continue to Step 5 (the task was already claimed in Step 1 - save its `.task` state file for the current branch; do NOT stop before it, or detect-task/`/lets:done` are left with a claim but no boundary file).
 
 If staying on current branch (worktree, already correct) or no changes - skip this step.
 
@@ -169,7 +169,7 @@ When triggered standalone (not via `/lets:start`):
 Task claimed: **{task title}** (`{task-id}`)
 Branch: {branch-name}
 
-┌─ LETS ───────────────────────────────────────────┐
+┌─ LETS ────────────────────────────────────────────┐
 │  Plan?    /lets:plan · --fast · plan-workflow     │
 │  Check?   /lets:check                             │
 └───────────────────────────────────────────────────┘


### PR DESCRIPTION
## Summary

Two-part cleanup after the command-flow-hygiene wave (dsdmp/mic6d/bh79a/qsgmd).

**(a) Remove orphaned fragile jq bindings.** The orient unification (#142) deleted the 5-view `/lets:status` dashboards; their priority-histogram (`bd list --status=open --json | jq …`) and per-label `--json --all` bindings in `tracker-beads.md` had no consumer left. Removed them - the fragile jq-over-bd-JSON control-char crash path (the original reason lets-qsgmd existed) leaves the adapter. **Not markdown-only after all:** a golden test pinned the removed binding, so the Go test was updated in lockstep.

**(b) Fable consistency audit.** Ran 3 fable-model agents (architecture / reference-integrity / governance) over the plugin surface. Fixed all 7 findings traceable to this worktree's tasks:
- **[BLOCKER]** `/lets:start --main` M1 did a full-file `session:`-only write that DESTROYED a live trunk claim's `task:`/`start:` -> merge-write that preserves them (dsdmp).
- **[BLOCKER]** Go golden test pinned the removed jq binding -> Go suite was red -> fixed.
- `take-task` Step 2 "Stay" claimed but wrote no `.task` file -> route through Step 5 (dsdmp).
- `execute.md` completion used the `session:` range (under-reported) + silent `Commits: 0` -> anchor on `start:`, hex-guard, degrade-loud (dsdmp).
- statusline tip + beads-only prose hints (`status.md`/`start.md`) -> updated / qualified (qsgmd).
- `take-task` welcome box header 52 -> 53 cols.

`go test ./...` green.

## Deferred (not this worktree's work)

Install-command stale refs, agent-count 14-vs-15, and `done.md` beads prose (tracker-platform #140) are carried to **lets-s7kut** (P0) - a full pre-release fable run over the consolidated `main`.

## Task

lets-d6vla: Post-orient consistency audit + remove orphaned jq bindings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VHrq2skGcweEMx8yLtbawm