### PR TITLE
fix: /lets:start --continue skips orient when one task is in progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixed
+- **`/lets:start --continue` resumes instead of re-orienting (lets-z1q8b).** With exactly one in_progress task the command still rendered the full orient snapshot (In flight / Next up / Project) and ran `list-by-status` twice, so a resume read like a backlog review. It now skips orient and task selection, shows only the recent-session recovery line, and hands straight to `take-task`, which reads the task comments and latest snapshot. Multiple in_progress tasks still get the snapshot for selection; none falls through to the full flow.
+
 ## [0.8.1] - 2026-08-23
 
 ### Added

--- a/plugins/lets/commands/start.md
+++ b/plugins/lets/commands/start.md
@@ -29,9 +29,10 @@ Restore context and prepare for work. **User MUST select a task before working.*
 
 **If `--continue`:**
 - Run Step 1 (session history) - important for context recovery
+- Run Step 2 (git state) briefly
 - the tracker's `list-by-status` (in_progress) - find task(s)
-- If exactly 1 in_progress -> use it, skip Step 5
-- If multiple -> show selection with context from recent sessions
+- If exactly 1 in_progress -> use it. **Skip Step 3 (orient) and Step 5** - the task is already known, so the Next up / Project snapshot is noise (and it would re-run `list-by-status` a second time inside orient). Present only the `## Recent Sessions` recovery line (Step 4), then jump to Step 6 (take-task) - its Step 6 context recovery reads the task comments + latest snapshot
+- If multiple -> run Step 3 (orient) and show selection with context from recent sessions
 - If none -> fall through to full flow
 
 **If `--main` or `--assistant` provided** (project-assistant / PM mode):
@@ -101,6 +102,8 @@ The orient snapshot (Step 3) already shows In flight + Next up - don't repeat th
 
 {orient snapshot from Step 3 - Where you are / In flight / Next up / Project}
 ```
+
+`--continue` with exactly one in_progress task skipped Step 3 - present only `## Recent Sessions` + one line naming the task being resumed, no snapshot.
 
 ## Step 5: What do we do? (task selection - MANDATORY)
 


### PR DESCRIPTION
## Summary
`/lets:start --continue` is meant to resume the last in_progress task with session context, but its Step 0 branch only said "skip Step 5". Step 3 (orient) still ran, so the user got the full snapshot (In flight, Next up, Project counts) even though the task was already known, and `list-by-status in_progress` ran twice. The `<task-id>` branch already skipped Steps 1, 3, 5 explicitly.

With exactly one in_progress task the command now skips orient and task selection, shows only the recent-session recovery line, and hands straight to `take-task`. Multiple in_progress tasks still get the snapshot for selection; none falls through to the full flow.

## Changes
- e476a3d fix(lets-z1q8b): skip orient on --continue with one task
- ac5ef30 docs(lets-z1q8b): update CHANGELOG

## Task
lets-z1q8b: Make /lets:start --continue skip orient when exactly one in_progress task exists

---
Generated with LETS plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vds5uAkg3QjA3oAwrzBAdH